### PR TITLE
Story: [CCMSPUI 767] Validate category of law

### DIFF
--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimsRestClient.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimsRestClient.java
@@ -9,6 +9,7 @@ import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PatchExchange;
 import org.springframework.web.service.annotation.PostExchange;
+import reactor.core.publisher.Mono;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimFields;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPost;
@@ -89,7 +90,7 @@ public interface DataClaimsRestClient {
    */
   @GetExchange("/submissions/{submission-id}/claims/{claim-id}")
   ResponseEntity<ClaimFields> getClaim(
-      @PathVariable("submission-id") String submissionId, @PathVariable("claim-id") String claimId);
+      @PathVariable("submission-id") UUID submissionId, @PathVariable("claim-id") UUID claimId);
 
   /**
    * Partially update fields of a specific claim.
@@ -100,9 +101,9 @@ public interface DataClaimsRestClient {
    * @return 204 No Content on success
    */
   @PatchExchange("/submissions/{submission-id}/claims/{claim-id}")
-  ResponseEntity<Void> updateClaim(
-      @PathVariable("submission-id") String submissionId,
-      @PathVariable("claim-id") String claimId,
+  Mono<Void> updateClaim(
+      @PathVariable("submission-id") UUID submissionId,
+      @PathVariable("claim-id") UUID claimId,
       @RequestBody ClaimPatch claimPatch);
 
   /**

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/exception/SubmissionRetrievalException.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/exception/SubmissionRetrievalException.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.exception;
+
+import java.util.UUID;
+
+/** Thrown when a requested submission cannot be retrieved from the Data Claims service. */
+public class SubmissionRetrievalException extends RuntimeException {
+  /**
+   * Constructs the exception with the identifier of the submission has errors retrieving data.
+   *
+   * @param submissionId the submission id that could not be retrieved
+   */
+  public SubmissionRetrievalException(UUID submissionId) {
+    super("Submission not retrievable: " + submissionId.toString());
+  }
+}

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/exception/SubmissionValidationException.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/exception/SubmissionValidationException.java
@@ -1,0 +1,13 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.exception;
+
+/** Thrown when a problem is found during submission validation. */
+public class SubmissionValidationException extends RuntimeException {
+  /**
+   * Constructs the exception with a message detailing the error during validation.
+   *
+   * @param message the message detailing the error
+   */
+  public SubmissionValidationException(String message) {
+    super(message);
+  }
+}

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/CategoryOfLawValidationService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/CategoryOfLawValidationService.java
@@ -1,0 +1,78 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimFields;
+import uk.gov.justice.laa.dstew.payments.claimsevent.client.FeeSchemePlatformRestClient;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationContext;
+import uk.gov.justice.laa.fee.scheme.model.CategoryOfLawResponse;
+
+/** A service responsible for validating data items related to category of law. */
+@Service
+@AllArgsConstructor
+public class CategoryOfLawValidationService {
+
+  private final SubmissionValidationContext submissionValidationContext;
+
+  private final FeeSchemePlatformRestClient feeSchemePlatformRestClient;
+
+  /**
+   * Validates that a valid category of law exists for the fee code provided in the claim.
+   *
+   * @param claim the submitted claim
+   * @param categoryOfLawLookup the lookup of feeCode -> categoryOfLaw for all claims in the
+   *     submission
+   */
+  public void validateCategoryOfLaw(
+      ClaimFields claim,
+      Map<String, String> categoryOfLawLookup,
+      List<String> providerCategoriesOfLaw) {
+
+    String categoryOfLaw = categoryOfLawLookup.get(claim.getFeeCode());
+
+    if (categoryOfLaw == null) {
+      submissionValidationContext.addClaimError(
+          claim.getId(), ClaimValidationError.INVALID_CATEGORY_OF_LAW_AND_FEE_CODE);
+    } else if (!providerCategoriesOfLaw.contains(categoryOfLaw)) {
+      submissionValidationContext.addClaimError(
+          claim.getId(), ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER);
+    }
+  }
+
+  /**
+   * Build a lookup of feeCode -> categoryOfLaw where feeCode are the unique fee codes found in the
+   * list of claims, and categoryOfLaw are the corresponding category of law that has been retrieved
+   * from the Fee Scheme Platform API.
+   *
+   * <p>Category of law may be null if none were found corresponding to the fee code.
+   *
+   * @param claims the list of claims (from the submission)
+   * @return the feeCode -> categoryOfLaw lookup
+   */
+  public Map<String, String> getCategoryOfLawLookup(List<ClaimFields> claims) {
+    Set<String> uniqueFeeCodes =
+        claims.stream().map(ClaimFields::getFeeCode).collect(Collectors.toSet());
+
+    return Flux.fromIterable(uniqueFeeCodes)
+        .flatMap(
+            feeCode ->
+                feeSchemePlatformRestClient
+                    .getCategoryOfLaw(feeCode)
+                    .map(CategoryOfLawResponse::getCategoryOfLawCode)
+                    .map(categoryOfLawResponse -> Map.entry(feeCode, categoryOfLawResponse))
+                    .onErrorResume(
+                        WebClientResponseException.NotFound.class,
+                        ex -> Mono.just(new AbstractMap.SimpleEntry<>(feeCode, null))))
+        .collectMap(Map.Entry::getKey, Map.Entry::getValue)
+        .block();
+  }
+}

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationService.java
@@ -1,0 +1,56 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimFields;
+
+/**
+ * A service for validating submitted claims that are ready to process. Validation errors will
+ * result in claims being marked as invalid and all validation errors will be reported against the
+ * claim.
+ */
+@Service
+@AllArgsConstructor
+public class ClaimValidationService {
+
+  private final CategoryOfLawValidationService categoryOfLawValidationService;
+  private final DuplicateClaimValidationService duplicateClaimValidationService;
+  private final FeeCalculationService feeCalculationService;
+
+  /**
+   * Validate a list of claims in a submission.
+   *
+   * @param claims the claims in a submission
+   */
+  public void validateClaims(List<ClaimFields> claims, List<String> providerCategoriesOfLaw) {
+    Map<String, String> categoryOfLawLookup =
+        categoryOfLawValidationService.getCategoryOfLawLookup(claims);
+    claims.forEach(claim -> validateClaim(claim, categoryOfLawLookup, providerCategoriesOfLaw));
+  }
+
+  /**
+   * Validate a claim.
+   *
+   * <p>Validates that:
+   *
+   * <ul>
+   *   <li>The claim's fee code is associated with a valid category of law
+   *   <li>The claim is not a duplicate
+   *   <li>The claim passes fee calculation
+   * </ul>
+   *
+   * @param claim the submitted claim
+   * @param categoryOfLawLookup the lookup of fee code -> category of law for the submission
+   */
+  private void validateClaim(
+      ClaimFields claim,
+      Map<String, String> categoryOfLawLookup,
+      List<String> providerCategoriesOfLaw) {
+    categoryOfLawValidationService.validateCategoryOfLaw(
+        claim, categoryOfLawLookup, providerCategoriesOfLaw);
+    duplicateClaimValidationService.validateDuplicateClaims(claim);
+    feeCalculationService.validateFeeCalculation(claim);
+  }
+}

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationService.java
@@ -1,0 +1,18 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimFields;
+
+/** Service responsible for validating whether a claim is a duplicate. */
+@Service
+public class DuplicateClaimValidationService {
+
+  /**
+   * Validates whether a claim has been previously submitted, and is therefore a duplicate.
+   *
+   * @param claim the submitted claim
+   */
+  public void validateDuplicateClaims(ClaimFields claim) {
+    // TODO: Duplicate validation. See https://dsdmoj.atlassian.net/browse/CCMSPUI-790.
+  }
+}

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/FeeCalculationService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/FeeCalculationService.java
@@ -1,0 +1,21 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimFields;
+
+/**
+ * Service responsible for validating the fee calculation response from the Fee Scheme Platform API.
+ */
+@Service
+public class FeeCalculationService {
+
+  /**
+   * Calculates the fee for the claim using the Fee Scheme Platform API, and handles any returned
+   * validation errors.
+   *
+   * @param claim the submitted claim
+   */
+  public void validateFeeCalculation(ClaimFields claim) {
+    // TODO: Calculate fee. See https://dsdmoj.atlassian.net/browse/CCMSPUI-825.
+  }
+}

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SubmissionValidationService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SubmissionValidationService.java
@@ -1,0 +1,153 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetSubmission200Response;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetSubmission200ResponseClaimsInner;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetSubmission200ResponseClaimsInner.StatusEnum;
+import uk.gov.justice.laa.dstew.payments.claimsevent.client.DataClaimsRestClient;
+import uk.gov.justice.laa.dstew.payments.claimsevent.client.ProviderDetailsRestClient;
+import uk.gov.justice.laa.dstew.payments.claimsevent.exception.SubmissionValidationException;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationReport;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationContext;
+import uk.gov.justice.laa.provider.model.FirmOfficeContractAndScheduleDetails;
+import uk.gov.justice.laa.provider.model.FirmOfficeContractAndScheduleLine;
+import uk.gov.justice.laa.provider.model.ProviderFirmOfficeContractAndScheduleDto;
+
+/**
+ * A service responsible for validating claim submissions. Any errors found during validation will
+ * be reported against the appropriate claims. Once validation is complete, the claim status and any
+ * validation errors will be sent to the Data Claims API.
+ */
+@Service
+@AllArgsConstructor
+public class SubmissionValidationService {
+
+  private final ClaimValidationService claimValidationService;
+  private final DataClaimsRestClient dataClaimsRestClient;
+  private final ProviderDetailsRestClient providerDetailsRestClient;
+  private final SubmissionValidationContext submissionValidationContext;
+
+  /**
+   * Validates a claim submission.
+   *
+   * @param submission the claim submission to validate
+   */
+  public void validateSubmission(GetSubmission200Response submission) {
+    if (submission.getSubmission() == null) {
+      throw new SubmissionValidationException("Submission is null");
+    }
+
+    List<ClaimFields> claims = getReadyToProcessClaims(submission);
+
+    initialiseValidationContext(claims);
+
+    validateNilSubmission(submission);
+
+    String officeCode = submission.getSubmission().getOfficeAccountNumber();
+    String areaOfLaw = submission.getSubmission().getAreaOfLaw();
+    List<String> providerCategoriesOfLaw = getProviderCategoriesOfLaw(officeCode, areaOfLaw);
+    validateProviderContract(providerCategoriesOfLaw);
+
+    claimValidationService.validateClaims(claims, providerCategoriesOfLaw);
+
+    UUID submissionId = submission.getSubmission().getSubmissionId();
+    updateClaims(submissionId, claims);
+  }
+
+  private void validateNilSubmission(GetSubmission200Response submission) {
+    if (Boolean.TRUE.equals(submission.getSubmission().getIsNilSubmission())) {
+      if (submission.getClaims() != null && !submission.getClaims().isEmpty()) {
+        submissionValidationContext.addToAllClaimReports(
+            ClaimValidationError.INVALID_NIL_SUBMISSION_CONTAINS_CLAIMS);
+      }
+    } else if (Boolean.FALSE.equals(submission.getSubmission().getIsNilSubmission())) {
+      if (submission.getClaims() == null || submission.getClaims().isEmpty()) {
+        throw new SubmissionValidationException(
+            "Submission is not marked as nil submission, but does not contain any claims");
+      }
+    }
+  }
+
+  private List<String> getProviderCategoriesOfLaw(String officeCode, String areaOfLaw) {
+    return providerDetailsRestClient
+        .getProviderFirmSchedules(officeCode, areaOfLaw)
+        .blockOptional()
+        .stream()
+        .map(ProviderFirmOfficeContractAndScheduleDto::getSchedules)
+        .flatMap(List::stream)
+        .map(FirmOfficeContractAndScheduleDetails::getScheduleLines)
+        .flatMap(List::stream)
+        .map(FirmOfficeContractAndScheduleLine::getCategoryOfLaw)
+        .toList();
+  }
+
+  private void validateProviderContract(List<String> providerCategoriesOfLaw) {
+    if (providerCategoriesOfLaw.isEmpty()) {
+      submissionValidationContext.addToAllClaimReports(
+          ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER);
+    }
+  }
+
+  private void updateClaims(UUID submissionId, List<ClaimFields> claims) {
+    List<Mono<Void>> updateRequests =
+        claims.stream()
+            .map(
+                claim ->
+                    ClaimPatch.builder()
+                        .id(claim.getId())
+                        .status(getClaimStatus(claim.getId()))
+                        .build())
+            .map(
+                claimPatch ->
+                    dataClaimsRestClient.updateClaim(
+                        submissionId, UUID.fromString(claimPatch.getId()), claimPatch))
+            .toList();
+
+    Flux.merge(updateRequests).subscribe();
+  }
+
+  private ClaimStatus getClaimStatus(String claimId) {
+    if (submissionValidationContext.hasErrors(claimId)) {
+      return ClaimStatus.INVALID;
+    } else {
+      return ClaimStatus.VALID;
+    }
+  }
+
+  private void initialiseValidationContext(List<ClaimFields> claims) {
+    List<ClaimValidationReport> claimValidationErrors =
+        claims.stream().map(ClaimFields::getId).map(ClaimValidationReport::new).toList();
+    submissionValidationContext.addClaimReports(claimValidationErrors);
+  }
+
+  /**
+   * Get data for all claims with READY_TO_PROCESS status in a submission.
+   *
+   * @param submission the submission
+   * @return a list of claims in the submission that are ready for processing.
+   */
+  private List<ClaimFields> getReadyToProcessClaims(GetSubmission200Response submission) {
+    if (submission.getClaims() == null) {
+      return Collections.emptyList();
+    }
+    return submission.getClaims().stream()
+        .filter(claim -> StatusEnum.READY_TO_PROCESS.equals(claim.getStatus()))
+        .map(GetSubmission200ResponseClaimsInner::getClaimId)
+        .map(
+            claimId ->
+                dataClaimsRestClient
+                    .getClaim(submission.getSubmission().getSubmissionId(), claimId)
+                    .getBody())
+        .toList();
+  }
+}

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/TempService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/TempService.java
@@ -20,6 +20,12 @@ public class TempService extends BulkParsingService {
 
   private final BulkSubmissionMapper bulkSubmissionMapper;
 
+  /**
+   * Construct temporary service.
+   *
+   * @param dataClaimsRestClient the data claims rest client
+   * @param bulkSubmissionMapper the bulk submission mapper
+   */
   public TempService(
       final DataClaimsRestClient dataClaimsRestClient,
       final BulkSubmissionMapper bulkSubmissionMapper) {

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationError.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationError.java
@@ -1,0 +1,19 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.validation;
+
+/** Enum holding claim validation errors. */
+public enum ClaimValidationError {
+  INVALID_AREA_OF_LAW_FOR_PROVIDER(
+      "A contract schedule with the provided area of law could not be found for this provider"),
+  INVALID_CATEGORY_OF_LAW_AND_FEE_CODE(
+      "A category of law could not be found for the provided fee code"),
+  INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER(
+      "The provider is not contracted for the category of law associated with the fee code"),
+  INVALID_NIL_SUBMISSION_CONTAINS_CLAIMS(
+      "Submission is marked as nil submission, but contains claims");
+
+  final String message;
+
+  ClaimValidationError(String message) {
+    this.message = message;
+  }
+}

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationReport.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationReport.java
@@ -1,0 +1,40 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * Class responsible for holding information about a claim under validation, including the claim ID
+ * and validation errors.
+ */
+@Getter
+@EqualsAndHashCode
+public class ClaimValidationReport {
+
+  private final String claimId;
+  private final List<ClaimValidationError> errors;
+
+  public ClaimValidationReport(String claimId) {
+    this.claimId = claimId;
+    this.errors = new ArrayList<>();
+  }
+
+  public ClaimValidationReport(String claimId, List<ClaimValidationError> errors) {
+    this.claimId = claimId;
+    this.errors = new ArrayList<>(errors);
+  }
+
+  public void addError(ClaimValidationError error) {
+    errors.add(error);
+  }
+
+  public void addErrors(List<ClaimValidationError> error) {
+    errors.addAll(error);
+  }
+
+  public boolean hasErrors() {
+    return !errors.isEmpty();
+  }
+}

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/SubmissionValidationContext.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/SubmissionValidationContext.java
@@ -1,0 +1,101 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+/**
+ * Class responsible for holding the validation context for a submission within the scope of a
+ * request. This will contain all claim errors reported during the request.
+ */
+@Getter
+@RequestScope
+@Component
+public class SubmissionValidationContext {
+
+  private final List<ClaimValidationReport> claimReports;
+
+  /**
+   * Construct a new {@code SubmissionValidationContext} with an initialised empty list of claim
+   * reports.
+   */
+  public SubmissionValidationContext() {
+    this.claimReports = new ArrayList<>();
+  }
+
+  /**
+   * Add a claim error to the validation context. If a report has not yet been created for the
+   * claim, creates a new claim report and adds the error. Otherwise, the error is added to the
+   * existing claim report.
+   *
+   * @param claimId the ID of the claim for which to report an error
+   * @param error the claim validation error
+   */
+  public void addClaimError(String claimId, ClaimValidationError error) {
+    claimReports.stream()
+        .filter(claimReport -> claimReport.getClaimId().equals(claimId))
+        .findFirst()
+        .ifPresentOrElse(
+            claimReport -> claimReport.addError(error),
+            () -> claimReports.add(new ClaimValidationReport(claimId, List.of(error))));
+  }
+
+  /**
+   * Add a list of claim reports to the validation context.
+   *
+   * @param reports the list of {@link ClaimValidationReport}
+   */
+  public void addClaimReports(List<ClaimValidationReport> reports) {
+    claimReports.addAll(reports);
+  }
+
+  /**
+   * Add a claim validation error to all current claim reports.
+   *
+   * @param error the {@link ClaimValidationError} to add
+   */
+  public void addToAllClaimReports(ClaimValidationError error) {
+    claimReports.forEach(claimReport -> claimReport.addError(error));
+  }
+
+  /**
+   * Get the claim report for an individual claim.
+   *
+   * @param claimId the ID of the claim for which to retrieve a report
+   * @return an optional {@link ClaimValidationReport}
+   */
+  public Optional<ClaimValidationReport> getClaimReport(String claimId) {
+    return claimReports.stream()
+        .filter(claimError -> claimError.getClaimId().equals(claimId))
+        .findFirst();
+  }
+
+  /**
+   * Determine whether the validation context contains any claim errors for the given claim ID.
+   *
+   * @param claimId the ID of the claim
+   * @return true of the claim report for the given claim has validation errors, false otherwise
+   */
+  public boolean hasErrors(String claimId) {
+    if (claimId == null) {
+      return false;
+    }
+    return claimReports.stream()
+        .filter(claimReport -> claimReport.getClaimId().equals(claimId))
+        .findFirst()
+        .map(ClaimValidationReport::hasErrors)
+        .orElse(false);
+  }
+
+  /**
+   * Determine whether the validation context has any claim errors.
+   *
+   * @return true if any claim has a validation error, false otherwise.
+   */
+  public boolean hasErrors() {
+    return claimReports.stream().anyMatch(ClaimValidationReport::hasErrors);
+  }
+}

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/BulkParsingServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/BulkParsingServiceTest.java
@@ -13,9 +13,9 @@ import static org.mockito.Mockito.when;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
@@ -44,12 +44,7 @@ class BulkParsingServiceTest {
   @Mock private DataClaimsRestClient dataClaimsRestClient;
   @Mock private BulkSubmissionMapper mapper;
 
-  private BulkParsingService service;
-
-  @BeforeEach
-  void setUp() {
-    service = new BulkParsingService(dataClaimsRestClient, mapper);
-  }
+  @InjectMocks private BulkParsingService service;
 
   @Test
   void parseDataProcessesSubmissionClaimsAndMatterStarts() {

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/CategoryOfLawValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/CategoryOfLawValidationServiceTest.java
@@ -1,0 +1,128 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimFields;
+import uk.gov.justice.laa.dstew.payments.claimsevent.client.FeeSchemePlatformRestClient;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationContext;
+import uk.gov.justice.laa.fee.scheme.model.CategoryOfLawResponse;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryOfLawValidationServiceTest {
+
+  @Mock SubmissionValidationContext submissionValidationContext;
+
+  @Mock FeeSchemePlatformRestClient feeSchemePlatformRestClient;
+
+  @InjectMocks CategoryOfLawValidationService categoryOfLawValidationService;
+
+  @Nested
+  @DisplayName("validateCategoryOfLaw")
+  class ValidateCategoryOfLawTests {
+
+    @Test
+    @DisplayName("Validates category of law without errors")
+    void validatesCategoryOfLawWithoutErrors() {
+      ClaimFields claim = new ClaimFields().id("claimId").feeCode("feeCode");
+      Map<String, String> categoryOfLawLookup = Map.of("feeCode", "categoryOfLaw");
+      List<String> providerCategoriesOfLaw = List.of("categoryOfLaw");
+
+      categoryOfLawValidationService.validateCategoryOfLaw(
+          claim, categoryOfLawLookup, providerCategoriesOfLaw);
+
+      verifyNoInteractions(submissionValidationContext);
+    }
+
+    @Test
+    @DisplayName(
+        "Marks claim as invalid when category of law could not be found for the provided "
+            + "fee code")
+    void marksClaimAsInvalidWhenCategoryOfLawNotFoundForFeeCode() {
+      ClaimFields claim = new ClaimFields().id("claimId").feeCode("feeCode");
+      Map<String, String> categoryOfLawLookup = new HashMap<>();
+      categoryOfLawLookup.put("feeCode", null);
+      List<String> providerCategoriesOfLaw = List.of("categoryOfLaw");
+
+      categoryOfLawValidationService.validateCategoryOfLaw(
+          claim, categoryOfLawLookup, providerCategoriesOfLaw);
+
+      verify(submissionValidationContext, times(1))
+          .addClaimError("claimId", ClaimValidationError.INVALID_CATEGORY_OF_LAW_AND_FEE_CODE);
+    }
+
+    @Test
+    @DisplayName("Marks claim as invalid when category of law not found in provider contracts")
+    void marksClaimAsInvalidWhenCategoryOfLawNotFoundForProvider() {
+      ClaimFields claim = new ClaimFields().id("claimId").feeCode("feeCode");
+      Map<String, String> categoryOfLawLookup = new HashMap<>();
+      categoryOfLawLookup.put("feeCode", "categoryOfLaw");
+      List<String> providerCategoriesOfLaw = Collections.emptyList();
+
+      categoryOfLawValidationService.validateCategoryOfLaw(
+          claim, categoryOfLawLookup, providerCategoriesOfLaw);
+
+      verify(submissionValidationContext, times(1))
+          .addClaimError(
+              "claimId", ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER);
+    }
+  }
+
+  @Nested
+  @DisplayName("getCategoryOfLawLookup")
+  class GetCategoryOfLawLookupTests {
+
+    @Test
+    @DisplayName("Returns map of fee code -> category of law")
+    void getCategoryOfLawLookup() {
+      ClaimFields claim1 = new ClaimFields().id("claimId1").feeCode("feeCode1");
+
+      ClaimFields claim2 = new ClaimFields().id("claimId2").feeCode("feeCode2");
+
+      ClaimFields claim3 = new ClaimFields().id("claimId3").feeCode("feeCode3");
+
+      CategoryOfLawResponse categoryOfLawResponse1 =
+          new CategoryOfLawResponse().categoryOfLawCode("categoryOfLaw1");
+
+      CategoryOfLawResponse categoryOfLawResponse2 =
+          new CategoryOfLawResponse().categoryOfLawCode("categoryOfLaw2");
+
+      when(feeSchemePlatformRestClient.getCategoryOfLaw("feeCode1"))
+          .thenReturn(Mono.just(categoryOfLawResponse1));
+
+      when(feeSchemePlatformRestClient.getCategoryOfLaw("feeCode2"))
+          .thenReturn(Mono.just(categoryOfLawResponse2));
+
+      when(feeSchemePlatformRestClient.getCategoryOfLaw("feeCode3"))
+          .thenReturn(
+              Mono.error(WebClientResponseException.create(404, "Not Found", null, null, null)));
+
+      Map<String, String> actual =
+          categoryOfLawValidationService.getCategoryOfLawLookup(List.of(claim1, claim2, claim3));
+
+      Map<String, String> expected = new HashMap<>();
+      expected.put("feeCode1", "categoryOfLaw1");
+      expected.put("feeCode2", "categoryOfLaw2");
+      expected.put("feeCode3", null);
+
+      assertThat(actual).isEqualTo(expected);
+    }
+  }
+}

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationServiceTest.java
@@ -1,0 +1,60 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimFields;
+
+@ExtendWith(MockitoExtension.class)
+class ClaimValidationServiceTest {
+
+  @Mock private CategoryOfLawValidationService categoryOfLawValidationService;
+
+  @Mock private DuplicateClaimValidationService duplicateClaimValidationService;
+
+  @Mock private FeeCalculationService feeCalculationService;
+
+  @InjectMocks private ClaimValidationService claimValidationService;
+
+  @Nested
+  @DisplayName("validateClaims")
+  class ValidateClaimsTests {
+
+    @Test
+    @DisplayName("Validates category of law, duplicates and fee calculation for all claims")
+    void validateCategoryOfLawAndDuplicatesAndFeeCalculation() {
+      ClaimFields claim1 = new ClaimFields().id("claim1").feeCode("feeCode1");
+      ClaimFields claim2 = new ClaimFields().id("claim2").feeCode("feeCode2");
+      List<ClaimFields> claims = List.of(claim1, claim2);
+      List<String> providerCategoriesOfLaw = List.of("categoryOfLaw1");
+      Map<String, String> categoryOfLawLookup = Collections.emptyMap();
+
+      when(categoryOfLawValidationService.getCategoryOfLawLookup(claims))
+          .thenReturn(categoryOfLawLookup);
+
+      claimValidationService.validateClaims(claims, providerCategoriesOfLaw);
+
+      verify(categoryOfLawValidationService, times(1))
+          .validateCategoryOfLaw(claim1, categoryOfLawLookup, providerCategoriesOfLaw);
+      verify(categoryOfLawValidationService, times(1))
+          .validateCategoryOfLaw(claim2, categoryOfLawLookup, providerCategoriesOfLaw);
+
+      verify(duplicateClaimValidationService, times(1)).validateDuplicateClaims(claim1);
+      verify(duplicateClaimValidationService, times(1)).validateDuplicateClaims(claim2);
+
+      verify(feeCalculationService, times(1)).validateFeeCalculation(claim1);
+      verify(feeCalculationService, times(1)).validateFeeCalculation(claim2);
+    }
+  }
+}

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SubmissionValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SubmissionValidationServiceTest.java
@@ -1,0 +1,267 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimFields;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetSubmission200Response;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetSubmission200ResponseClaimsInner;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetSubmission200ResponseClaimsInner.StatusEnum;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionFields;
+import uk.gov.justice.laa.dstew.payments.claimsevent.client.DataClaimsRestClient;
+import uk.gov.justice.laa.dstew.payments.claimsevent.client.ProviderDetailsRestClient;
+import uk.gov.justice.laa.dstew.payments.claimsevent.exception.SubmissionValidationException;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationContext;
+import uk.gov.justice.laa.provider.model.FirmOfficeContractAndScheduleDetails;
+import uk.gov.justice.laa.provider.model.FirmOfficeContractAndScheduleLine;
+import uk.gov.justice.laa.provider.model.ProviderFirmOfficeContractAndScheduleDto;
+
+@ExtendWith(MockitoExtension.class)
+public class SubmissionValidationServiceTest {
+
+  @Mock private ClaimValidationService claimValidationService;
+
+  @Mock private DataClaimsRestClient dataClaimsRestClient;
+
+  @Mock private ProviderDetailsRestClient providerDetailsRestClient;
+
+  @Mock private SubmissionValidationContext submissionValidationContext;
+
+  @InjectMocks private SubmissionValidationService submissionValidationService;
+
+  @Nested
+  @DisplayName("validateSubmission")
+  class ValidateSubmissionTests {
+
+    @Test
+    @DisplayName("Marks claims as valid if no validation errors found")
+    void updatesClaims() {
+      // Given
+      UUID submissionId = new UUID(0, 0);
+      UUID claimId = new UUID(1, 1);
+      String areaOfLaw = "areaOfLaw";
+      String categoryOfLaw = "categoryOfLaw";
+      String officeAccountNumber = "officeAccountNumber";
+
+      SubmissionFields submissionFields = new SubmissionFields();
+      submissionFields.setSubmissionId(submissionId);
+      submissionFields.setAreaOfLaw(areaOfLaw);
+      submissionFields.setOfficeAccountNumber(officeAccountNumber);
+
+      GetSubmission200ResponseClaimsInner claim = new GetSubmission200ResponseClaimsInner();
+      claim.setClaimId(claimId);
+      claim.setStatus(StatusEnum.READY_TO_PROCESS);
+
+      GetSubmission200Response submission =
+          GetSubmission200Response.builder()
+              .submission(submissionFields)
+              .claims(List.of(claim))
+              .build();
+
+      ClaimFields claimFields = new ClaimFields();
+      claimFields.id(claimId.toString());
+      claimFields.feeCode("feeCode");
+
+      when(dataClaimsRestClient.getClaim(submissionId, claimId))
+          .thenReturn(ResponseEntity.of(Optional.of(claimFields)));
+
+      FirmOfficeContractAndScheduleLine scheduleLine = new FirmOfficeContractAndScheduleLine();
+      scheduleLine.setCategoryOfLaw(categoryOfLaw);
+
+      FirmOfficeContractAndScheduleDetails schedule = new FirmOfficeContractAndScheduleDetails();
+      schedule.scheduleLines(List.of(scheduleLine));
+
+      ProviderFirmOfficeContractAndScheduleDto providerFirmResponse =
+          new ProviderFirmOfficeContractAndScheduleDto();
+      providerFirmResponse.addSchedulesItem(schedule);
+
+      when(providerDetailsRestClient.getProviderFirmSchedules(officeAccountNumber, areaOfLaw))
+          .thenReturn(Mono.just(providerFirmResponse));
+
+      ClaimPatch claimPatch = new ClaimPatch().id(claimId.toString()).status(ClaimStatus.VALID);
+
+      when(submissionValidationContext.hasErrors(claimId.toString())).thenReturn(false);
+
+      when(dataClaimsRestClient.updateClaim(submissionId, claimId, claimPatch))
+          .thenReturn(Mono.empty());
+
+      // When
+      submissionValidationService.validateSubmission(submission);
+
+      // Then
+      verify(dataClaimsRestClient, times(1)).getClaim(submissionId, claimId);
+      verify(providerDetailsRestClient, times(1))
+          .getProviderFirmSchedules(officeAccountNumber, areaOfLaw);
+      verify(claimValidationService, times(1))
+          .validateClaims(List.of(claimFields), List.of(categoryOfLaw));
+      verify(dataClaimsRestClient, times(1)).updateClaim(submissionId, claimId, claimPatch);
+    }
+
+    @Test
+    @DisplayName("Marks claims as invalid if nil submission contains claims")
+    void marksClaimsAsInvalidIfNilSubmissionContainsClaims() {
+      // Given
+      UUID submissionId = new UUID(0, 0);
+      UUID claimId = new UUID(1, 1);
+      String areaOfLaw = "areaOfLaw";
+      String categoryOfLaw = "categoryOfLaw";
+      String officeAccountNumber = "officeAccountNumber";
+
+      SubmissionFields submissionFields = new SubmissionFields();
+      submissionFields.setSubmissionId(submissionId);
+      submissionFields.setAreaOfLaw(areaOfLaw);
+      submissionFields.setOfficeAccountNumber(officeAccountNumber);
+      submissionFields.setIsNilSubmission(true);
+
+      GetSubmission200ResponseClaimsInner claim = new GetSubmission200ResponseClaimsInner();
+      claim.setClaimId(claimId);
+      claim.setStatus(StatusEnum.READY_TO_PROCESS);
+
+      GetSubmission200Response submission =
+          GetSubmission200Response.builder()
+              .submission(submissionFields)
+              .claims(List.of(claim))
+              .build();
+
+      ClaimFields claimFields = new ClaimFields();
+      claimFields.id(claimId.toString());
+      claimFields.feeCode("feeCode");
+
+      when(dataClaimsRestClient.getClaim(submissionId, claimId))
+          .thenReturn(ResponseEntity.of(Optional.of(claimFields)));
+
+      FirmOfficeContractAndScheduleLine scheduleLine = new FirmOfficeContractAndScheduleLine();
+      scheduleLine.setCategoryOfLaw(categoryOfLaw);
+
+      FirmOfficeContractAndScheduleDetails schedule = new FirmOfficeContractAndScheduleDetails();
+      schedule.scheduleLines(List.of(scheduleLine));
+
+      ProviderFirmOfficeContractAndScheduleDto providerFirmResponse =
+          new ProviderFirmOfficeContractAndScheduleDto();
+      providerFirmResponse.addSchedulesItem(schedule);
+
+      when(providerDetailsRestClient.getProviderFirmSchedules(officeAccountNumber, areaOfLaw))
+          .thenReturn(Mono.just(providerFirmResponse));
+
+      ClaimPatch claimPatch = new ClaimPatch().id(claimId.toString()).status(ClaimStatus.INVALID);
+
+      when(dataClaimsRestClient.updateClaim(submissionId, claimId, claimPatch))
+          .thenReturn(Mono.empty());
+
+      when(submissionValidationContext.hasErrors(claimId.toString())).thenReturn(true);
+
+      // When
+      submissionValidationService.validateSubmission(submission);
+
+      // Then
+      verify(submissionValidationContext, times(1))
+          .addToAllClaimReports(ClaimValidationError.INVALID_NIL_SUBMISSION_CONTAINS_CLAIMS);
+      verify(dataClaimsRestClient, times(1)).getClaim(submissionId, claimId);
+      verify(providerDetailsRestClient, times(1))
+          .getProviderFirmSchedules(officeAccountNumber, areaOfLaw);
+      verify(claimValidationService, times(1))
+          .validateClaims(List.of(claimFields), List.of(categoryOfLaw));
+      verify(dataClaimsRestClient, times(1)).updateClaim(submissionId, claimId, claimPatch);
+    }
+
+    @Test
+    @DisplayName(
+        "Throws exception if submission not marked as nil submission contains no " + "claims")
+    void throwsExceptionIfSubmissionNotMarkedAsNilSubmissionContainsNoClaims() {
+      // Given
+      UUID submissionId = new UUID(0, 0);
+      String areaOfLaw = "areaOfLaw";
+      String officeAccountNumber = "officeAccountNumber";
+
+      SubmissionFields submissionFields = new SubmissionFields();
+      submissionFields.setSubmissionId(submissionId);
+      submissionFields.setAreaOfLaw(areaOfLaw);
+      submissionFields.setOfficeAccountNumber(officeAccountNumber);
+      submissionFields.setIsNilSubmission(false);
+
+      GetSubmission200Response submission =
+          GetSubmission200Response.builder().submission(submissionFields).claims(null).build();
+
+      // When
+      assertThrows(
+          SubmissionValidationException.class,
+          () -> submissionValidationService.validateSubmission(submission),
+          "Expected SubmissionValidationException to be thrown");
+    }
+
+    @Test
+    @DisplayName("Marks claims as invalid if provider contract is invalid")
+    void marksClaimsAsInvalidIfProviderContractInvalid() {
+      // Given
+      UUID submissionId = new UUID(0, 0);
+      UUID claimId = new UUID(1, 1);
+      String areaOfLaw = "areaOfLaw";
+      String officeAccountNumber = "officeAccountNumber";
+
+      SubmissionFields submissionFields = new SubmissionFields();
+      submissionFields.setSubmissionId(submissionId);
+      submissionFields.setAreaOfLaw(areaOfLaw);
+      submissionFields.setOfficeAccountNumber(officeAccountNumber);
+
+      GetSubmission200ResponseClaimsInner claim = new GetSubmission200ResponseClaimsInner();
+      claim.setClaimId(claimId);
+      claim.setStatus(StatusEnum.READY_TO_PROCESS);
+
+      GetSubmission200Response submission =
+          GetSubmission200Response.builder()
+              .submission(submissionFields)
+              .claims(List.of(claim))
+              .build();
+
+      ClaimFields claimFields = new ClaimFields();
+      claimFields.id(claimId.toString());
+      claimFields.feeCode("feeCode");
+
+      when(dataClaimsRestClient.getClaim(submissionId, claimId))
+          .thenReturn(ResponseEntity.of(Optional.of(claimFields)));
+
+      when(providerDetailsRestClient.getProviderFirmSchedules(officeAccountNumber, areaOfLaw))
+          .thenReturn(Mono.empty());
+
+      ClaimPatch claimPatch = new ClaimPatch().id(claimId.toString()).status(ClaimStatus.INVALID);
+
+      when(submissionValidationContext.hasErrors(claimId.toString())).thenReturn(false);
+
+      when(dataClaimsRestClient.updateClaim(submissionId, claimId, claimPatch))
+          .thenReturn(Mono.empty());
+
+      when(submissionValidationContext.hasErrors(claimId.toString())).thenReturn(true);
+
+      // When
+      submissionValidationService.validateSubmission(submission);
+
+      // Then
+      verify(submissionValidationContext, times(1))
+          .addToAllClaimReports(ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER);
+      verify(dataClaimsRestClient, times(1)).getClaim(submissionId, claimId);
+      verify(providerDetailsRestClient, times(1))
+          .getProviderFirmSchedules(officeAccountNumber, areaOfLaw);
+      verify(claimValidationService, times(1))
+          .validateClaims(List.of(claimFields), Collections.emptyList());
+      verify(dataClaimsRestClient, times(1)).updateClaim(submissionId, claimId, claimPatch);
+    }
+  }
+}

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SubmissionValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SubmissionValidationServiceTest.java
@@ -183,8 +183,7 @@ public class SubmissionValidationServiceTest {
     }
 
     @Test
-    @DisplayName(
-        "Throws exception if submission not marked as nil submission contains no " + "claims")
+    @DisplayName("Throws exception if submission not marked as nil submission contains no claims")
     void throwsExceptionIfSubmissionNotMarkedAsNilSubmissionContainsNoClaims() {
       // Given
       UUID submissionId = new UUID(0, 0);

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationReportTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationReportTest.java
@@ -1,0 +1,95 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ClaimValidationReportTest {
+
+  ClaimValidationReport claimValidationReport;
+
+  @Nested
+  @DisplayName("addError")
+  class AddErrorTests {
+
+    @Test
+    @DisplayName("Correctly adds an error")
+    void correctlyAddsError() {
+      // Given
+      claimValidationReport =
+          new ClaimValidationReport(
+              "claimId",
+              List.of(ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER));
+
+      // When
+      claimValidationReport.addError(ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER);
+
+      // Then
+      assertThat(claimValidationReport.getErrors().size()).isEqualTo(2);
+      assertThat(claimValidationReport.getErrors())
+          .contains(
+              ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER,
+              ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER);
+    }
+  }
+
+  @Nested
+  @DisplayName("addErrors")
+  class AddErrorsTests {
+
+    @Test
+    @DisplayName("Correctly adds errors")
+    void addErrors() {
+      // Given
+      claimValidationReport =
+          new ClaimValidationReport(
+              "claimId",
+              List.of(ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER));
+
+      // When
+      claimValidationReport.addErrors(
+          List.of(
+              ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER,
+              ClaimValidationError.INVALID_CATEGORY_OF_LAW_AND_FEE_CODE));
+
+      // Then
+      assertThat(claimValidationReport.getErrors().size()).isEqualTo(3);
+      assertThat(claimValidationReport.getErrors())
+          .contains(
+              ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER,
+              ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER,
+              ClaimValidationError.INVALID_CATEGORY_OF_LAW_AND_FEE_CODE);
+    }
+  }
+
+  @Nested
+  @DisplayName("hasErrors")
+  class HasErrorsTests {
+
+    @Test
+    @DisplayName("Returns true when errors are present")
+    void returnsTrueWhenErrorsPresent() {
+      // Given
+      claimValidationReport =
+          new ClaimValidationReport(
+              "claimId",
+              List.of(ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER));
+
+      // Then
+      assertThat(claimValidationReport.hasErrors()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Returns false when no errors are present")
+    void returnsFalseWhenNoErrorsPresent() {
+      // Given
+      claimValidationReport = new ClaimValidationReport("claimId");
+
+      // Then
+      assertThat(claimValidationReport.hasErrors()).isFalse();
+    }
+  }
+}

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/SubmissionValidationContextTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/SubmissionValidationContextTest.java
@@ -149,6 +149,8 @@ class SubmissionValidationContextTest {
       // When
       Optional<ClaimValidationReport> actual =
           submissionValidationContext.getClaimReport("claimId1");
+
+      // Then
       assertThat(actual.isPresent()).isTrue();
       assertThat(actual.get()).isEqualTo(claimValidationReport1);
     }

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/SubmissionValidationContextTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/SubmissionValidationContextTest.java
@@ -1,0 +1,230 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SubmissionValidationContextTest {
+
+  SubmissionValidationContext submissionValidationContext;
+
+  @Nested
+  @DisplayName("addClaimError")
+  class AddClaimErrorTests {
+
+    @Test
+    @DisplayName("Handles errors for new claim reports")
+    void handlesClaimErrorForNewClaim() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+
+      assertThat(submissionValidationContext.getClaimReports()).isEmpty();
+
+      // When
+      submissionValidationContext.addClaimError(
+          "claimId", ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER);
+
+      // Then
+      ClaimValidationReport expected =
+          new ClaimValidationReport(
+              "claimId", List.of(ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER));
+
+      assertThat(submissionValidationContext.getClaimReports()).hasSize(1);
+      assertThat(submissionValidationContext.getClaimReports().getFirst()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Handles errors for existing claim reports")
+    void handlesClaimErrorForExistingClaim() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+
+      assertThat(submissionValidationContext.getClaimReports()).isEmpty();
+
+      submissionValidationContext.addClaimError(
+          "claimId", ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER);
+
+      assertThat(submissionValidationContext.getClaimReports()).hasSize(1);
+
+      // When
+      submissionValidationContext.addClaimError(
+          "claimId", ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER);
+
+      // Then
+      ClaimValidationReport expected =
+          new ClaimValidationReport(
+              "claimId",
+              List.of(
+                  ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER,
+                  ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER));
+
+      assertThat(submissionValidationContext.getClaimReports()).hasSize(1);
+      assertThat(submissionValidationContext.getClaimReports().getFirst()).isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  @DisplayName("addClaimReports")
+  class AddClaimReportsTest {
+
+    @Test
+    @DisplayName("Correctly adds a claim report")
+    void correctlyAddsClaimReports() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+
+      assertThat(submissionValidationContext.getClaimReports()).isEmpty();
+
+      // When
+      ClaimValidationReport claimValidationReport1 = new ClaimValidationReport("claimId1");
+      ClaimValidationReport claimValidationReport2 = new ClaimValidationReport("claimId2");
+      submissionValidationContext.addClaimReports(
+          List.of(claimValidationReport1, claimValidationReport2));
+
+      // Then
+      assertThat(submissionValidationContext.getClaimReports()).hasSize(2);
+      assertThat(submissionValidationContext.getClaimReports())
+          .isEqualTo(List.of(claimValidationReport1, claimValidationReport2));
+    }
+  }
+
+  @Nested
+  @DisplayName("addToAllClaimReports")
+  class AddToAllClaimReportsTests {
+
+    @Test
+    @DisplayName("Correctly adds error to all existing claims")
+    void correctlyAddsErrorToAllClaims() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+
+      assertThat(submissionValidationContext.getClaimReports()).isEmpty();
+
+      ClaimValidationReport claimValidationReport1 = new ClaimValidationReport("claimId1");
+      ClaimValidationReport claimValidationReport2 = new ClaimValidationReport("claimId2");
+      submissionValidationContext.addClaimReports(
+          List.of(claimValidationReport1, claimValidationReport2));
+
+      assertThat(submissionValidationContext.getClaimReports()).hasSize(2);
+
+      // When
+      submissionValidationContext.addToAllClaimReports(
+          ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER);
+
+      // Then
+      List<ClaimValidationReport> expected =
+          List.of(
+              new ClaimValidationReport(
+                  "claimId1", List.of(ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER)),
+              new ClaimValidationReport(
+                  "claimId2", List.of(ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER)));
+      assertThat(submissionValidationContext.getClaimReports()).hasSize(2);
+      assertThat(submissionValidationContext.getClaimReports()).isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  @DisplayName("getClaimReport")
+  class GetClaimReportTests {
+
+    @Test
+    @DisplayName("Correctly gets the claim report for the given claim ID")
+    void correctlyGetsReportForTheGivenClaimId() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+
+      ClaimValidationReport claimValidationReport1 =
+          new ClaimValidationReport(
+              "claimId1", List.of(ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER));
+      ClaimValidationReport claimValidationReport2 =
+          new ClaimValidationReport(
+              "claimId2", List.of(ClaimValidationError.INVALID_CATEGORY_OF_LAW_AND_FEE_CODE));
+      submissionValidationContext.addClaimReports(
+          List.of(claimValidationReport1, claimValidationReport2));
+
+      // When
+      Optional<ClaimValidationReport> actual =
+          submissionValidationContext.getClaimReport("claimId1");
+      assertThat(actual.isPresent()).isTrue();
+      assertThat(actual.get()).isEqualTo(claimValidationReport1);
+    }
+  }
+
+  @Nested
+  @DisplayName("hasErrors")
+  class HasErrorsTests {
+
+    @Test
+    @DisplayName("Returns true if the claim report with the given claim ID has errors")
+    void returnsTrueForClaimReportsWithErrors() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+      submissionValidationContext.addClaimReports(
+          List.of(
+              new ClaimValidationReport(
+                  "claimId", List.of(ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER))));
+
+      // Then
+      assertThat(submissionValidationContext.getClaimReports()).hasSize(1);
+      assertThat(submissionValidationContext.hasErrors("claimId")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Returns false if the claim report with the given claim ID does not have errors")
+    void returnsFalseForClaimReportsWithoutErrors() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+      submissionValidationContext.addClaimReports(List.of(new ClaimValidationReport("claimId")));
+
+      // Then
+      assertThat(submissionValidationContext.getClaimReports()).hasSize(1);
+      assertThat(submissionValidationContext.hasErrors("claimId")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Returns false no claim report exists for the given claim ID")
+    void returnsFalseForMissingClaimReports() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+
+      // Then
+      assertThat(submissionValidationContext.hasErrors("claimId")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Returns false when none of the claim reports in the context have errors")
+    void returnsFalseWhenNoneOfTheClaimReportsHaveErrors() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+
+      ClaimValidationReport claimValidationReport1 = new ClaimValidationReport("claimId1");
+      ClaimValidationReport claimValidationReport2 = new ClaimValidationReport("claimId2");
+      submissionValidationContext.addClaimReports(
+          List.of(claimValidationReport1, claimValidationReport2));
+
+      // Then
+      assertThat(submissionValidationContext.hasErrors()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Returns true when any of the claim reports in the context have errors")
+    void returnsTrueWhenAnyOfTheClaimReportsHaveErrors() {
+      // Given
+      submissionValidationContext = new SubmissionValidationContext();
+
+      ClaimValidationReport claimValidationReport1 =
+          new ClaimValidationReport(
+              "claimId1", List.of(ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER));
+      ClaimValidationReport claimValidationReport2 = new ClaimValidationReport("claimId2");
+      submissionValidationContext.addClaimReports(
+          List.of(claimValidationReport1, claimValidationReport2));
+
+      // Then
+      assertThat(submissionValidationContext.hasErrors()).isTrue();
+    }
+  }
+}

--- a/reference-data-claim-api/open-api-specification.yml
+++ b/reference-data-claim-api/open-api-specification.yml
@@ -77,6 +77,8 @@ paths:
           description: 'Unauthorized'
         '403':
           description: 'Forbidden'
+        '415':
+          description: 'Unsupported Media Type'
         '500':
           description: 'Internal server error'
 
@@ -277,9 +279,6 @@ paths:
                   type: string
                 delivery_location:
                   type: string
-                number_of_matter_starts:
-                  type: integer
-                  example: 3
       responses:
         '201':
           description: Matter Start created successfully
@@ -543,6 +542,9 @@ components:
         number_of_claims:
           type: integer
           description: Number of claims in this submission.
+        submitted:
+          type: date
+          description: Date the submission was submitted
 
     ClaimPost:
       allOf:
@@ -572,6 +574,8 @@ components:
       type: object
       description: Claim details
       properties:
+        id:
+          type: string
         status:
           $ref: "#/components/schemas/ClaimStatus"
         schedule_reference:
@@ -634,6 +638,8 @@ components:
           type: string
         referral_source:
           type: string
+        total_value:
+          type: number
         client_forename:
           type: string
         client_surname:
@@ -788,13 +794,13 @@ components:
       type: object
       description: matter start details for a bulk submission
       properties:
-        accessPoint:
-          type: string
-        mat:
-          type: string
-        immas:
+        scheduleRef:
           type: string
         categoryCode:
+          type: string
+        procurementArea:
+          type: string
+        accessPoint:
           type: string
         deliveryLocation:
           type: string
@@ -854,22 +860,22 @@ components:
           type: integer
         profitCost:
           type: number
-          format: double
+          format: bigDecimal
         valueOfCosts:
           type: number
-          format: double
+          format: bigDecimal
         disbursementsAmount:
           type: number
-          format: double
+          format: bigDecimal
         counselCost:
           type: number
-          format: double
+          format: bigDecimal
         disbursementsVat:
           type: number
-          format: double
+          format: bigDecimal
         travelWaitingCosts:
           type: number
-          format: double
+          format: bigDecimal
         vatIndicator:
           type: boolean
         londonNonlondonRate:
@@ -880,7 +886,7 @@ components:
           type: boolean
         travelCosts:
           type: number
-          format: double
+          format: bigDecimal
         outcomeCode:
           type: string
         legacyCase:
@@ -889,7 +895,7 @@ components:
           type: string
         adjournedHearingFee:
           type: number
-          format: double
+          format: bigDecimal
         typeOfAdvice:
           type: string
         postalApplAccp:
@@ -913,7 +919,7 @@ components:
           format: date
         detentionTravelWaitingCosts:
           type: number
-          format: double
+          format: bigDecimal
         deliveryLocation:
           type: string
         priorAuthorityRef:
@@ -1023,7 +1029,7 @@ components:
           type: string
         excessTravelCosts:
           type: number
-          format: double
+          format: bigDecimal
         medConcludedDate:
           type: string
           format: date


### PR DESCRIPTION
## Summary

[CCMSPUI-767](https://dsdmoj.atlassian.net/browse/CCMSPUI-767)

Implemented service for validating claims within a submission, including validation of

- category of law (this ticket)
- duplicate claims (https://dsdmoj.atlassian.net/browse/CCMSPUI-790)
- fee calculation (https://dsdmoj.atlassian.net/browse/CCMSPUI-825)

Also updated Data Claims API OpenAPI spec to the latest version.

## Checklist

Before you ask people to review this PR, please confirm:

- [x] The build pipeline is passing.
- [x] There are no conflicts with the target branch.
- [x] There are no whitespace-only changes.
- [x] There are no unexpected changes.


[CCMSPUI-767]: https://dsdmoj.atlassian.net/browse/CCMSPUI-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ