### PR TITLE
Story [CCMSPUI 828] Add duplicate checks for crime claims

### DIFF
--- a/data-claims-event-service/build.gradle
+++ b/data-claims-event-service/build.gradle
@@ -57,6 +57,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    implementation 'org.springframework.data:spring-data-commons'
+
     // Import spring-cloud-aws BOM (Bill Of Materials) for dependency management
     implementation platform('io.awspring.cloud:spring-cloud-aws:3.4.0')
     implementation 'io.awspring.cloud:spring-cloud-aws-starter'

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimsRestClient.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimsRestClient.java
@@ -14,6 +14,7 @@ import org.springframework.web.service.annotation.PostExchange;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPost;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResultSet;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.CreateMatterStart201Response;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetBulkSubmission200Response;
@@ -87,22 +88,22 @@ public interface DataClaimsRestClient {
   /**
    * Get claims in an office, filtering on certain criteria.
    *
-   * @param submissionStatus the status of the parent submission
+   * @param submissionStatuses the statuses of the parent submissions
    * @param feeCode the fee code of the claim
    * @param uniqueFileNumber the unique file number of the claim
    * @param uniqueClientNumber the unique client number of the claim
-   * @param claimStatus the claim status
+   * @param claimStatuses the claim statuses
    * @return 200 OK with JSON body containing the list of matched claims
    */
-  @PostExchange("/claims")
-  ResponseEntity<List<ClaimResponse>> getClaims(
+  @GetExchange("/claims")
+  ResponseEntity<ClaimResultSet> getClaims(
       @RequestParam String officeCode,
       @RequestParam(required = false) String submissionId,
-      @RequestParam(required = false) List<SubmissionStatus> submissionStatus,
+      @RequestParam(required = false) List<SubmissionStatus> submissionStatuses,
       @RequestParam(required = false) String feeCode,
       @RequestParam(required = false) String uniqueFileNumber,
       @RequestParam(required = false) String uniqueClientNumber,
-      @RequestParam(required = false) List<ClaimStatus> claimStatus);
+      @RequestParam(required = false) List<ClaimStatus> claimStatuses);
 
   /**
    * Get a specific claim for a submission.

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimsRestClient.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimsRestClient.java
@@ -1,10 +1,12 @@
 package uk.gov.justice.laa.dstew.payments.claimsevent.client;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PatchExchange;
@@ -12,12 +14,14 @@ import org.springframework.web.service.annotation.PostExchange;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPost;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.CreateMatterStart201Response;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.GetBulkSubmission200Response;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.MatterStartPost;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionPatch;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionPost;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionResponse;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionStatus;
 
 /**
  * REST client interface for fetching claims data. This interface communicates with the Data Claims
@@ -79,6 +83,26 @@ public interface DataClaimsRestClient {
   @PostExchange("/submissions/{id}/claims")
   ResponseEntity<Void> createClaim(
       @PathVariable("id") String submissionId, @RequestBody ClaimPost claim);
+
+  /**
+   * Get claims in an office, filtering on certain criteria.
+   *
+   * @param submissionStatus the status of the parent submission
+   * @param feeCode the fee code of the claim
+   * @param uniqueFileNumber the unique file number of the claim
+   * @param uniqueClientNumber the unique client number of the claim
+   * @param claimStatus the claim status
+   * @return 200 OK with JSON body containing the list of matched claims
+   */
+  @PostExchange("/claims")
+  ResponseEntity<List<ClaimResponse>> getClaims(
+      @RequestParam String officeCode,
+      @RequestParam(required = false) String submissionId,
+      @RequestParam(required = false) List<SubmissionStatus> submissionStatus,
+      @RequestParam(required = false) String feeCode,
+      @RequestParam(required = false) String uniqueFileNumber,
+      @RequestParam(required = false) String uniqueClientNumber,
+      @RequestParam(required = false) List<ClaimStatus> claimStatus);
 
   /**
    * Get a specific claim for a submission.

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimsRestClient.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimsRestClient.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.dstew.payments.claimsevent.client;
 
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -103,7 +104,8 @@ public interface DataClaimsRestClient {
       @RequestParam(required = false) String feeCode,
       @RequestParam(required = false) String uniqueFileNumber,
       @RequestParam(required = false) String uniqueClientNumber,
-      @RequestParam(required = false) List<ClaimStatus> claimStatuses);
+      @RequestParam(required = false) List<ClaimStatus> claimStatuses,
+      Pageable pageable);
 
   /**
    * Get a specific claim for a submission.

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/CategoryOfLawValidationService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/CategoryOfLawValidationService.java
@@ -22,8 +22,6 @@ import uk.gov.justice.laa.fee.scheme.model.CategoryOfLawResponse;
 @AllArgsConstructor
 public class CategoryOfLawValidationService {
 
-  private final SubmissionValidationContext submissionValidationContext;
-
   private final FeeSchemePlatformRestClient feeSchemePlatformRestClient;
 
   /**
@@ -36,22 +34,23 @@ public class CategoryOfLawValidationService {
   public void validateCategoryOfLaw(
       ClaimResponse claim,
       Map<String, CategoryOfLawResult> categoryOfLawLookup,
-      List<String> providerCategoriesOfLaw) {
+      List<String> providerCategoriesOfLaw,
+      SubmissionValidationContext context) {
 
     log.debug("Validating category of law for claim {}", claim.getId());
 
     CategoryOfLawResult categoryOfLawResult = categoryOfLawLookup.get(claim.getFeeCode());
 
     if (categoryOfLawResult.isError()) {
-      submissionValidationContext.flagForRetry(claim.getId());
+      context.flagForRetry(claim.getId());
     } else {
       String categoryOfLaw = categoryOfLawResult.getCategoryOfLaw();
 
       if (categoryOfLaw == null) {
-        submissionValidationContext.addClaimError(
+        context.addClaimError(
             claim.getId(), ClaimValidationError.INVALID_CATEGORY_OF_LAW_AND_FEE_CODE);
       } else if (!providerCategoriesOfLaw.contains(categoryOfLaw)) {
-        submissionValidationContext.addClaimError(
+        context.addClaimError(
             claim.getId(),
             ClaimValidationError.INVALID_CATEGORY_OF_LAW_NOT_AUTHORISED_FOR_PROVIDER);
       }

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationService.java
@@ -42,6 +42,7 @@ public class ClaimValidationService {
                 null,
                 null,
                 null,
+                null,
                 null)
             .getBody()
             .getContent();

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationService.java
@@ -117,7 +117,8 @@ public class DuplicateClaimValidationService {
             feeCode,
             uniqueFileNumber,
             null,
-            List.of(ClaimStatus.VALID, ClaimStatus.READY_TO_PROCESS))
+            List.of(ClaimStatus.VALID, ClaimStatus.READY_TO_PROCESS),
+            null)
         .getBody()
         .getContent()
         .stream()

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationService.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationService.java
@@ -1,22 +1,146 @@
 package uk.gov.justice.laa.dstew.payments.claimsevent.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionStatus;
+import uk.gov.justice.laa.dstew.payments.claimsevent.client.DataClaimsRestClient;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationContext;
 
 /** Service responsible for validating whether a claim is a duplicate. */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class DuplicateClaimValidationService {
+
+  private final DataClaimsRestClient dataClaimsRestClient;
+  private final SubmissionValidationContext submissionValidationContext;
 
   /**
    * Validates whether a claim has been previously submitted, and is therefore a duplicate.
    *
    * @param claim the submitted claim
    */
-  public void validateDuplicateClaims(ClaimResponse claim) {
-    log.debug("Validating duplicated for claim {}", claim.getId());
-    // TODO: Duplicate validation. See https://dsdmoj.atlassian.net/browse/CCMSPUI-790.
+  public void validateDuplicateClaims(
+      ClaimResponse claim,
+      List<ClaimResponse> submissionClaims,
+      String areaOfLaw,
+      String officeCode) {
+    log.debug("Validating duplicates for claim {}", claim.getId());
+    if (!submissionValidationContext.isFlaggedForRetry(claim.getId())) {
+      List<ClaimResponse> claimsToCompare = getOtherClaimsInSubmission(claim, submissionClaims);
+
+      List<ClaimResponse> submissionDuplicateClaims = new ArrayList<>();
+      List<ClaimResponse> officeDuplicateClaims = new ArrayList<>();
+
+      if ("CRIME_LOWER".equals(areaOfLaw)) {
+        String feeCode = claim.getFeeCode();
+        String uniqueFileNumber = claim.getUniqueFileNumber();
+        List<String> submissionClaimIds =
+            submissionClaims.stream().map(ClaimResponse::getId).toList();
+
+        submissionDuplicateClaims =
+            findDuplicates(
+                claimsToCompare,
+                claimToCompare ->
+                    feeCode.equals(claimToCompare.getFeeCode())
+                        && uniqueFileNumber.equals(claimToCompare.getUniqueFileNumber()));
+
+        officeDuplicateClaims =
+            searchOfficeClaims(officeCode, feeCode, uniqueFileNumber, submissionClaimIds);
+      }
+
+      if (!submissionDuplicateClaims.isEmpty()) {
+        log.debug("Duplicate claims found in submission");
+        logDuplicates(claim, submissionDuplicateClaims);
+        submissionValidationContext.addClaimError(
+            claim.getId(), ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION);
+      }
+      if (officeDuplicateClaims != null && !officeDuplicateClaims.isEmpty()) {
+        log.debug("Duplicate claims found in another submission for this office");
+        logDuplicates(claim, officeDuplicateClaims);
+        submissionValidationContext.addClaimError(
+            claim.getId(), ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_ANOTHER_SUBMISSION);
+      }
+    }
     log.debug("Duplicate validation completed for claim {}", claim.getId());
+  }
+
+  /**
+   * Filter the claims in the submission to contain all claims except the one currently under
+   * validation.
+   *
+   * @param claim the claim to filter
+   * @param submissionClaims the list of claims in the submission
+   * @return a filtered list of claims in the submission, excluding the given claim
+   */
+  private List<ClaimResponse> getOtherClaimsInSubmission(
+      ClaimResponse claim, List<ClaimResponse> submissionClaims) {
+    return submissionClaims.stream()
+        .filter(submissionClaim -> submissionClaim != claim)
+        .filter(
+            submissionClaim ->
+                List.of(ClaimStatus.READY_TO_PROCESS, ClaimStatus.VALID)
+                    .contains(submissionClaim.getStatus()))
+        .toList();
+  }
+
+  /**
+   * Search for duplicates in all other claims made by this office, with the same office code, fee
+   * code, and unique file number. Ignore claims within this submission as they are verified
+   * separately.
+   *
+   * @param officeCode the unique identifier for the office
+   * @param feeCode the fee code
+   * @param uniqueFileNumber the unique file number for the claim
+   * @param submissionClaimIds the IDs of the other claims in the submission
+   * @return a list of duplicates across other claims by the same office
+   */
+  private List<ClaimResponse> searchOfficeClaims(
+      String officeCode, String feeCode, String uniqueFileNumber, List<String> submissionClaimIds) {
+    return dataClaimsRestClient
+        .getClaims(
+            officeCode,
+            null,
+            List.of(
+                SubmissionStatus.CREATED,
+                SubmissionStatus.VALIDATION_IN_PROGRESS,
+                SubmissionStatus.READY_FOR_VALIDATION),
+            feeCode,
+            uniqueFileNumber,
+            null,
+            List.of(ClaimStatus.VALID, ClaimStatus.READY_TO_PROCESS))
+        .getBody()
+        .stream()
+        .filter(otherClaim -> !submissionClaimIds.contains(otherClaim.getId()))
+        .toList();
+  }
+
+  private void logDuplicates(ClaimResponse claim, List<ClaimResponse> duplicateClaims) {
+    List<String> duplicateClaimIds = duplicateClaims.stream().map(ClaimResponse::getId).toList();
+    log.debug(
+        "{} duplicate claims found matching claim {}. Duplicates: {}",
+        duplicateClaims.size(),
+        claim.getId(),
+        duplicateClaimIds);
+  }
+
+  /**
+   * Find duplicates in a list of claims, using a predicate to determine whether the claim is a
+   * duplicate.
+   *
+   * @param claimsToCompare the list of claims to compare against
+   * @param duplicatePredicate predicate to determine whether a claim is a duplicate
+   * @return the list of duplicate claims, as determined by the given predicate
+   */
+  private List<ClaimResponse> findDuplicates(
+      List<ClaimResponse> claimsToCompare, Predicate<ClaimResponse> duplicatePredicate) {
+    return claimsToCompare.stream().filter(duplicatePredicate).toList();
   }
 }

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationError.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationError.java
@@ -14,7 +14,11 @@ public enum ClaimValidationError {
   INVALID_NIL_SUBMISSION_CONTAINS_CLAIMS(
       "Submission is marked as nil submission, but contains claims"),
   INVALID_FEE_CALCULATION_VALIDATION_FAILED(
-      "A validation error occurred when attempting to calculate the fee for this claim");
+      "A validation error occurred when attempting to calculate the fee for this claim"),
+  INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION(
+      "A duplicate claim was found within the same submission"),
+  INVALID_CLAIM_HAS_DUPLICATE_IN_ANOTHER_SUBMISSION(
+      "A duplicate claim was found in another submission");
 
   final String description;
 

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationError.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/ClaimValidationError.java
@@ -15,7 +15,7 @@ public enum ClaimValidationError {
       "Submission is marked as nil submission, but contains claims"),
   INVALID_FEE_CALCULATION_VALIDATION_FAILED(
       "A validation error occurred when attempting to calculate the fee for this claim"),
-  INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION(
+  INVALID_CLAIM_HAS_DUPLICATE_IN_EXISTING_SUBMISSION(
       "A duplicate claim was found within the same submission"),
   INVALID_CLAIM_HAS_DUPLICATE_IN_ANOTHER_SUBMISSION(
       "A duplicate claim was found in another submission");

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/SubmissionValidationContext.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/SubmissionValidationContext.java
@@ -3,17 +3,15 @@ package uk.gov.justice.laa.dstew.payments.claimsevent.validation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import org.springframework.stereotype.Component;
-import org.springframework.web.context.annotation.RequestScope;
 
 /**
  * Class responsible for holding the validation context for a submission within the scope of a
  * request. This will contain all claim errors reported during the request.
  */
 @Getter
-@RequestScope
-@Component
+@EqualsAndHashCode
 public class SubmissionValidationContext {
 
   private final List<ClaimValidationReport> claimReports;

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationServiceTest.java
@@ -68,6 +68,7 @@ class ClaimValidationServiceTest {
               null,
               null,
               null,
+              null,
               null))
           .thenReturn(ResponseEntity.ok(claimResultSet));
 

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ClaimValidationServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,10 +15,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionResponse;
+import uk.gov.justice.laa.dstew.payments.claimsevent.client.DataClaimsRestClient;
 
 @ExtendWith(MockitoExtension.class)
 class ClaimValidationServiceTest {
+
+  @Mock private DataClaimsRestClient dataClaimsRestClient;
 
   @Mock private CategoryOfLawValidationService categoryOfLawValidationService;
 
@@ -34,24 +41,44 @@ class ClaimValidationServiceTest {
     @Test
     @DisplayName("Validates category of law, duplicates and fee calculation for all claims")
     void validateCategoryOfLawAndDuplicatesAndFeeCalculation() {
-      ClaimResponse claim1 = new ClaimResponse().id("claim1").feeCode("feeCode1");
-      ClaimResponse claim2 = new ClaimResponse().id("claim2").feeCode("feeCode2");
+      ClaimResponse claim1 =
+          new ClaimResponse().id("claim1").feeCode("feeCode1").status(ClaimStatus.READY_TO_PROCESS);
+      ClaimResponse claim2 =
+          new ClaimResponse().id("claim2").feeCode("feeCode2").status(ClaimStatus.READY_TO_PROCESS);
       List<ClaimResponse> claims = List.of(claim1, claim2);
       List<String> providerCategoriesOfLaw = List.of("categoryOfLaw1");
       Map<String, CategoryOfLawResult> categoryOfLawLookup = Collections.emptyMap();
 
+      SubmissionResponse submissionResponse =
+          new SubmissionResponse()
+              .submissionId(new UUID(1, 1))
+              .areaOfLaw("areaOfLaw")
+              .officeAccountNumber("officeAccountNumber");
+
+      when(dataClaimsRestClient.getClaims(
+              submissionResponse.getOfficeAccountNumber(),
+              submissionResponse.getSubmissionId().toString(),
+              null,
+              null,
+              null,
+              null,
+              null))
+          .thenReturn(ResponseEntity.ok(claims));
+
       when(categoryOfLawValidationService.getCategoryOfLawLookup(claims))
           .thenReturn(categoryOfLawLookup);
 
-      claimValidationService.validateClaims(claims, providerCategoriesOfLaw);
+      claimValidationService.validateClaims(submissionResponse, providerCategoriesOfLaw);
 
       verify(categoryOfLawValidationService, times(1))
           .validateCategoryOfLaw(claim1, categoryOfLawLookup, providerCategoriesOfLaw);
       verify(categoryOfLawValidationService, times(1))
           .validateCategoryOfLaw(claim2, categoryOfLawLookup, providerCategoriesOfLaw);
 
-      verify(duplicateClaimValidationService, times(1)).validateDuplicateClaims(claim1);
-      verify(duplicateClaimValidationService, times(1)).validateDuplicateClaims(claim2);
+      verify(duplicateClaimValidationService, times(1))
+          .validateDuplicateClaims(claim1, claims, "areaOfLaw", "officeAccountNumber");
+      verify(duplicateClaimValidationService, times(1))
+          .validateDuplicateClaims(claim2, claims, "areaOfLaw", "officeAccountNumber");
 
       verify(feeCalculationService, times(1)).validateFeeCalculation(claim1);
       verify(feeCalculationService, times(1)).validateFeeCalculation(claim2);

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationServiceTest.java
@@ -188,7 +188,9 @@ class DuplicateClaimValidationServiceTest {
       // Then
       assertThat(context.hasErrors(claim1.getId())).isTrue();
       assertContextClaimError(
-          context, claim1.getId(), ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION);
+          context,
+          claim1.getId(),
+          ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_EXISTING_SUBMISSION);
     }
 
     @Test
@@ -320,7 +322,9 @@ class DuplicateClaimValidationServiceTest {
 
       // Then
       assertContextClaimError(
-          context, claim1.getId(), ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION);
+          context,
+          claim1.getId(),
+          ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_EXISTING_SUBMISSION);
       assertThat(context.hasErrors(claim2.getId())).isFalse();
     }
   }

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationServiceTest.java
@@ -1,0 +1,280 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.dstew.payments.claimsevent.client.DataClaimsRestClient;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationContext;
+
+@ExtendWith(MockitoExtension.class)
+class DuplicateClaimValidationServiceTest {
+
+  @Mock DataClaimsRestClient dataClaimsRestClient;
+
+  @Mock SubmissionValidationContext submissionValidationContext;
+
+  @InjectMocks DuplicateClaimValidationService duplicateClaimValidationService;
+
+  @Nested
+  @DisplayName("validateDuplicateClaims")
+  class ValidateDuplicateClaimsTests {
+
+    @Test
+    @DisplayName("Crime claims - successful validation does not update context")
+    void crimeClaimSuccessfulValidation() {
+      // Given
+      ClaimResponse claim1 =
+          new ClaimResponse()
+              .id("claimId1")
+              .feeCode("feeCode1")
+              .uniqueFileNumber("ufn1")
+              .status(ClaimStatus.READY_TO_PROCESS);
+      ClaimResponse claim2 =
+          new ClaimResponse()
+              .id("claimId2")
+              .feeCode("feeCode2")
+              .uniqueFileNumber("ufn2")
+              .status(ClaimStatus.READY_TO_PROCESS);
+
+      List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
+
+      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+
+      // When
+      duplicateClaimValidationService.validateDuplicateClaims(
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+
+      // Then
+      verify(submissionValidationContext, times(1)).isFlaggedForRetry("claimId1");
+      verifyNoMoreInteractions(submissionValidationContext);
+    }
+
+    @Test
+    @DisplayName(
+        "Crime claims - different fee code but the same unique file number passes validation")
+    void crimeClaimDifferentFeeCodeButSameUfnPassesValidation() {
+      // Given
+      ClaimResponse claim1 =
+          new ClaimResponse()
+              .id("claimId1")
+              .feeCode("feeCode1")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.READY_TO_PROCESS);
+      ClaimResponse claim2 =
+          new ClaimResponse()
+              .id("claimId2")
+              .feeCode("feeCode2")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.READY_TO_PROCESS);
+
+      List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
+
+      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+
+      // When
+      duplicateClaimValidationService.validateDuplicateClaims(
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+
+      // Then
+      verify(submissionValidationContext, times(1)).isFlaggedForRetry("claimId1");
+      verifyNoMoreInteractions(submissionValidationContext);
+    }
+
+    @Test
+    @DisplayName(
+        "Crime claims - different unique file number but the same fee code passes validation")
+    void crimeClaimDifferentUfnButSameFeeCodePassesValidation() {
+      // Given
+      ClaimResponse claim1 =
+          new ClaimResponse()
+              .id("claimId1")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn1")
+              .status(ClaimStatus.READY_TO_PROCESS);
+      ClaimResponse claim2 =
+          new ClaimResponse()
+              .id("claimId2")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn2")
+              .status(ClaimStatus.READY_TO_PROCESS);
+
+      List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
+
+      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+
+      // When
+      duplicateClaimValidationService.validateDuplicateClaims(
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+
+      // Then
+      verify(submissionValidationContext, times(1)).isFlaggedForRetry("claimId1");
+      verifyNoMoreInteractions(submissionValidationContext);
+    }
+
+    @Test
+    @DisplayName(
+        "Crime claims - duplicate claims in submission results in claim error added to validation "
+            + "context")
+    void crimeClaimDuplicateInSubmissionResultsInClaimErrorAddedToContext() {
+      // Given
+      ClaimResponse claim1 =
+          new ClaimResponse()
+              .id("claimId1")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.READY_TO_PROCESS);
+      ClaimResponse claim2 =
+          new ClaimResponse()
+              .id("claimId2")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.READY_TO_PROCESS);
+
+      List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
+
+      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+
+      // When
+      duplicateClaimValidationService.validateDuplicateClaims(
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+
+      // Then
+      verify(submissionValidationContext, times(1))
+          .addClaimError(
+              "claimId1", ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION);
+    }
+
+    @Test
+    @DisplayName("Crime claims - duplicate validation ignores invalid claims")
+    void crimeClaimDuplicateValidationIgnoresInvalidClaims() {
+      // Given
+      ClaimResponse claim1 =
+          new ClaimResponse()
+              .id("claimId1")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.READY_TO_PROCESS);
+      ClaimResponse claim2 =
+          new ClaimResponse()
+              .id("claimId2")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.INVALID);
+
+      List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
+
+      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+
+      // When
+      duplicateClaimValidationService.validateDuplicateClaims(
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+
+      // Then
+      verify(submissionValidationContext, times(1)).isFlaggedForRetry("claimId1");
+      verifyNoMoreInteractions(submissionValidationContext);
+    }
+
+    @Test
+    @DisplayName(
+        "Crime claims - duplicate claims in another submission results in claim error added to "
+            + "validation context")
+    void crimeClaimDuplicateInAnotherSubmissionResultsInClaimErrorAddedToContext() {
+      // Given
+      ClaimResponse claim1 =
+          new ClaimResponse()
+              .id("claimId1")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.READY_TO_PROCESS);
+
+      ClaimResponse otherClaim =
+          new ClaimResponse()
+              .id("claimId2")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.VALID);
+
+      List<ClaimResponse> submissionClaims = List.of(claim1);
+
+      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(ResponseEntity.of(Optional.of(List.of(otherClaim))));
+
+      // When
+      duplicateClaimValidationService.validateDuplicateClaims(
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+
+      // Then
+      verify(submissionValidationContext, times(1))
+          .addClaimError(
+              "claimId1", ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_ANOTHER_SUBMISSION);
+    }
+
+    @Test
+    @DisplayName("Crime claims - does not reprocess submission claims")
+    void crimeClaimDuplicateDoesNotReprocessSubmissionClaims() {
+      // Given
+      ClaimResponse claim1 =
+          new ClaimResponse()
+              .id("claimId1")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.READY_TO_PROCESS);
+      ClaimResponse claim2 =
+          new ClaimResponse()
+              .id("claimId2")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.READY_TO_PROCESS);
+      ClaimResponse otherClaim =
+          new ClaimResponse()
+              .id("claimId2")
+              .feeCode("feeCode")
+              .uniqueFileNumber("ufn")
+              .status(ClaimStatus.READY_TO_PROCESS);
+
+      List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
+
+      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(ResponseEntity.of(Optional.of(List.of(otherClaim))));
+
+      // When
+      duplicateClaimValidationService.validateDuplicateClaims(
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+
+      // Then
+      verify(submissionValidationContext, times(1))
+          .addClaimError(
+              "claimId1", ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION);
+      verifyNoMoreInteractions(submissionValidationContext);
+    }
+  }
+}

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationServiceTest.java
@@ -1,12 +1,10 @@
 package uk.gov.justice.laa.dstew.payments.claimsevent.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.laa.dstew.payments.claimsevent.service.ValidationServiceTestUtils.assertContextClaimError;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -18,17 +16,17 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResultSet;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 import uk.gov.justice.laa.dstew.payments.claimsevent.client.DataClaimsRestClient;
 import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationReport;
 import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationContext;
 
 @ExtendWith(MockitoExtension.class)
 class DuplicateClaimValidationServiceTest {
 
   @Mock DataClaimsRestClient dataClaimsRestClient;
-
-  @Mock SubmissionValidationContext submissionValidationContext;
 
   @InjectMocks DuplicateClaimValidationService duplicateClaimValidationService;
 
@@ -55,17 +53,22 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
 
-      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
       when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
-          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+          .thenReturn(ResponseEntity.of(Optional.of(new ClaimResultSet())));
+
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(
+          List.of(
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim2.getId())));
 
       // When
       duplicateClaimValidationService.validateDuplicateClaims(
-          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode", context);
 
       // Then
-      verify(submissionValidationContext, times(1)).isFlaggedForRetry("claimId1");
-      verifyNoMoreInteractions(submissionValidationContext);
+      assertThat(context.hasErrors()).isFalse();
     }
 
     @Test
@@ -88,17 +91,22 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
 
-      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
       when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
-          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+          .thenReturn(ResponseEntity.of(Optional.of(new ClaimResultSet())));
+
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(
+          List.of(
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim2.getId())));
 
       // When
       duplicateClaimValidationService.validateDuplicateClaims(
-          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode", context);
 
       // Then
-      verify(submissionValidationContext, times(1)).isFlaggedForRetry("claimId1");
-      verifyNoMoreInteractions(submissionValidationContext);
+      assertThat(context.hasErrors()).isFalse();
     }
 
     @Test
@@ -121,17 +129,22 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
 
-      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
       when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
-          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+          .thenReturn(ResponseEntity.of(Optional.of(new ClaimResultSet())));
+
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(
+          List.of(
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim2.getId())));
 
       // When
       duplicateClaimValidationService.validateDuplicateClaims(
-          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode", context);
 
       // Then
-      verify(submissionValidationContext, times(1)).isFlaggedForRetry("claimId1");
-      verifyNoMoreInteractions(submissionValidationContext);
+      assertThat(context.hasErrors()).isFalse();
     }
 
     @Test
@@ -155,18 +168,27 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
 
-      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      ClaimResultSet claimResultSet = new ClaimResultSet();
+      claimResultSet.content(submissionClaims);
+
       when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
-          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+          .thenReturn(ResponseEntity.of(Optional.of(new ClaimResultSet())));
+
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(
+          List.of(
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim2.getId())));
 
       // When
       duplicateClaimValidationService.validateDuplicateClaims(
-          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode", context);
 
       // Then
-      verify(submissionValidationContext, times(1))
-          .addClaimError(
-              "claimId1", ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION);
+      assertThat(context.hasErrors(claim1.getId())).isTrue();
+      assertContextClaimError(
+          context, claim1.getId(), ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION);
     }
 
     @Test
@@ -188,17 +210,25 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
 
-      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      ClaimResultSet claimResultSet = new ClaimResultSet();
+      claimResultSet.content(submissionClaims);
+
       when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
-          .thenReturn(ResponseEntity.of(Optional.of(Collections.emptyList())));
+          .thenReturn(ResponseEntity.of(Optional.of(claimResultSet)));
+
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(
+          List.of(
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim2.getId())));
 
       // When
       duplicateClaimValidationService.validateDuplicateClaims(
-          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode", context);
 
       // Then
-      verify(submissionValidationContext, times(1)).isFlaggedForRetry("claimId1");
-      verifyNoMoreInteractions(submissionValidationContext);
+      assertThat(context.hasErrors()).isFalse();
     }
 
     @Test
@@ -223,18 +253,28 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1);
 
-      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      ClaimResultSet claimResultSet = new ClaimResultSet();
+      claimResultSet.content(List.of(otherClaim));
+
       when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
-          .thenReturn(ResponseEntity.of(Optional.of(List.of(otherClaim))));
+          .thenReturn(ResponseEntity.of(Optional.of(claimResultSet)));
+
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(
+          List.of(
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim1.getId())));
 
       // When
       duplicateClaimValidationService.validateDuplicateClaims(
-          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode", context);
 
       // Then
-      verify(submissionValidationContext, times(1))
-          .addClaimError(
-              "claimId1", ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_ANOTHER_SUBMISSION);
+      assertThat(context.hasErrors(claim1.getId())).isTrue();
+      assertContextClaimError(
+          context,
+          claim1.getId(),
+          ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_ANOTHER_SUBMISSION);
     }
 
     @Test
@@ -262,19 +302,26 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
 
-      when(submissionValidationContext.isFlaggedForRetry("claimId1")).thenReturn(false);
+      ClaimResultSet claimResultSet = new ClaimResultSet();
+      claimResultSet.content(List.of(otherClaim));
+
       when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
-          .thenReturn(ResponseEntity.of(Optional.of(List.of(otherClaim))));
+          .thenReturn(ResponseEntity.of(Optional.of(claimResultSet)));
+
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(
+          List.of(
+              new ClaimValidationReport(claim1.getId()),
+              new ClaimValidationReport(claim2.getId())));
 
       // When
       duplicateClaimValidationService.validateDuplicateClaims(
-          claim1, submissionClaims, "CRIME_LOWER", "officeCode");
+          claim1, submissionClaims, "CRIME_LOWER", "officeCode", context);
 
       // Then
-      verify(submissionValidationContext, times(1))
-          .addClaimError(
-              "claimId1", ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION);
-      verifyNoMoreInteractions(submissionValidationContext);
+      assertContextClaimError(
+          context, claim1.getId(), ClaimValidationError.INVALID_CLAIM_HAS_DUPLICATE_IN_SUBMISSION);
+      assertThat(context.hasErrors(claim2.getId())).isFalse();
     }
   }
 }

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/DuplicateClaimValidationServiceTest.java
@@ -53,7 +53,7 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
 
-      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any(), any()))
           .thenReturn(ResponseEntity.of(Optional.of(new ClaimResultSet())));
 
       SubmissionValidationContext context = new SubmissionValidationContext();
@@ -91,7 +91,7 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
 
-      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any(), any()))
           .thenReturn(ResponseEntity.of(Optional.of(new ClaimResultSet())));
 
       SubmissionValidationContext context = new SubmissionValidationContext();
@@ -129,7 +129,7 @@ class DuplicateClaimValidationServiceTest {
 
       List<ClaimResponse> submissionClaims = List.of(claim1, claim2);
 
-      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any(), any()))
           .thenReturn(ResponseEntity.of(Optional.of(new ClaimResultSet())));
 
       SubmissionValidationContext context = new SubmissionValidationContext();
@@ -171,7 +171,7 @@ class DuplicateClaimValidationServiceTest {
       ClaimResultSet claimResultSet = new ClaimResultSet();
       claimResultSet.content(submissionClaims);
 
-      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any(), any()))
           .thenReturn(ResponseEntity.of(Optional.of(new ClaimResultSet())));
 
       SubmissionValidationContext context = new SubmissionValidationContext();
@@ -215,7 +215,7 @@ class DuplicateClaimValidationServiceTest {
       ClaimResultSet claimResultSet = new ClaimResultSet();
       claimResultSet.content(submissionClaims);
 
-      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any(), any()))
           .thenReturn(ResponseEntity.of(Optional.of(claimResultSet)));
 
       SubmissionValidationContext context = new SubmissionValidationContext();
@@ -258,7 +258,7 @@ class DuplicateClaimValidationServiceTest {
       ClaimResultSet claimResultSet = new ClaimResultSet();
       claimResultSet.content(List.of(otherClaim));
 
-      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any(), any()))
           .thenReturn(ResponseEntity.of(Optional.of(claimResultSet)));
 
       SubmissionValidationContext context = new SubmissionValidationContext();
@@ -307,7 +307,7 @@ class DuplicateClaimValidationServiceTest {
       ClaimResultSet claimResultSet = new ClaimResultSet();
       claimResultSet.content(List.of(otherClaim));
 
-      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any()))
+      when(dataClaimsRestClient.getClaims(any(), any(), any(), any(), any(), any(), any(), any()))
           .thenReturn(ResponseEntity.of(Optional.of(claimResultSet)));
 
       SubmissionValidationContext context = new SubmissionValidationContext();

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/FeeCalculationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/FeeCalculationServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.dstew.payments.claimsevent.service;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -55,6 +56,8 @@ class FeeCalculationServiceTest {
       feeCalculationService.validateFeeCalculation(claim);
 
       verify(feeSchemePlatformRestClient, times(1)).calculateFee(feeCalculationRequest);
+      verify(validationContext, times(1)).isFlaggedForRetry("claimId");
+      verifyNoMoreInteractions(validationContext);
     }
 
     @Test

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/FeeCalculationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/FeeCalculationServiceTest.java
@@ -1,12 +1,13 @@
 package uk.gov.justice.laa.dstew.payments.claimsevent.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import java.util.List;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
 import uk.gov.justice.laa.dstew.payments.claimsevent.client.FeeSchemePlatformRestClient;
 import uk.gov.justice.laa.dstew.payments.claimsevent.mapper.FeeSchemeMapper;
 import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationReport;
 import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationContext;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
@@ -26,8 +28,6 @@ import uk.gov.justice.laa.fee.scheme.model.Warning;
 
 @ExtendWith(MockitoExtension.class)
 class FeeCalculationServiceTest {
-
-  @Mock private SubmissionValidationContext validationContext;
 
   @Mock private FeeSchemePlatformRestClient feeSchemePlatformRestClient;
 
@@ -51,13 +51,14 @@ class FeeCalculationServiceTest {
       when(feeSchemeMapper.mapToFeeCalculationRequest(claim)).thenReturn(feeCalculationRequest);
       when(feeSchemePlatformRestClient.calculateFee(feeCalculationRequest))
           .thenReturn(ResponseEntity.ok(feeCalculationResponse));
-      when(validationContext.isFlaggedForRetry("claimId")).thenReturn(false);
 
-      feeCalculationService.validateFeeCalculation(claim);
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(List.of(new ClaimValidationReport(claim.getId())));
+
+      feeCalculationService.validateFeeCalculation(claim, context);
 
       verify(feeSchemePlatformRestClient, times(1)).calculateFee(feeCalculationRequest);
-      verify(validationContext, times(1)).isFlaggedForRetry("claimId");
-      verifyNoMoreInteractions(validationContext);
+      assertThat(context.hasErrors()).isFalse();
     }
 
     @Test
@@ -75,13 +76,20 @@ class FeeCalculationServiceTest {
       when(feeSchemeMapper.mapToFeeCalculationRequest(claim)).thenReturn(feeCalculationRequest);
       when(feeSchemePlatformRestClient.calculateFee(feeCalculationRequest))
           .thenReturn(ResponseEntity.ok(feeCalculationResponse));
-      when(validationContext.isFlaggedForRetry("claimId")).thenReturn(false);
 
-      feeCalculationService.validateFeeCalculation(claim);
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(List.of(new ClaimValidationReport(claim.getId())));
+
+      feeCalculationService.validateFeeCalculation(claim, context);
 
       verify(feeSchemePlatformRestClient, times(1)).calculateFee(feeCalculationRequest);
-      verify(validationContext, times(1))
-          .addClaimError("claimId", ClaimValidationError.INVALID_FEE_CALCULATION_VALIDATION_FAILED);
+      assertThat(context.hasErrors(claim.getId())).isTrue();
+      assertThat(context.getClaimReport(claim.getId()))
+          .isPresent()
+          .get()
+          .extracting(ClaimValidationReport::getErrors)
+          .asInstanceOf(InstanceOfAssertFactories.LIST)
+          .containsExactly(ClaimValidationError.INVALID_FEE_CALCULATION_VALIDATION_FAILED);
     }
 
     @Test
@@ -95,15 +103,15 @@ class FeeCalculationServiceTest {
       when(feeSchemeMapper.mapToFeeCalculationRequest(claim)).thenReturn(feeCalculationRequest);
       when(feeSchemePlatformRestClient.calculateFee(feeCalculationRequest))
           .thenReturn(ResponseEntity.notFound().build());
-      when(validationContext.isFlaggedForRetry("claimId")).thenReturn(false);
 
-      ThrowingCallable result = () -> feeCalculationService.validateFeeCalculation(claim);
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(List.of(new ClaimValidationReport(claim.getId())));
 
-      feeCalculationService.validateFeeCalculation(claim);
+      feeCalculationService.validateFeeCalculation(claim, context);
 
       verify(feeSchemePlatformRestClient, times(1)).calculateFee(feeCalculationRequest);
 
-      verify(validationContext, times(1)).flagForRetry(claim.getId());
+      assertThat(context.isFlaggedForRetry(claim.getId())).isTrue();
     }
 
     @Test
@@ -117,13 +125,15 @@ class FeeCalculationServiceTest {
       when(feeSchemeMapper.mapToFeeCalculationRequest(claim)).thenReturn(feeCalculationRequest);
       when(feeSchemePlatformRestClient.calculateFee(feeCalculationRequest))
           .thenReturn(ResponseEntity.internalServerError().build());
-      when(validationContext.isFlaggedForRetry("claimId")).thenReturn(false);
 
-      feeCalculationService.validateFeeCalculation(claim);
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(List.of(new ClaimValidationReport(claim.getId())));
+
+      feeCalculationService.validateFeeCalculation(claim, context);
 
       verify(feeSchemePlatformRestClient, times(1)).calculateFee(feeCalculationRequest);
 
-      verify(validationContext, times(1)).flagForRetry(claim.getId());
+      assertThat(context.isFlaggedForRetry(claim.getId())).isTrue();
     }
 
     @Test
@@ -132,12 +142,18 @@ class FeeCalculationServiceTest {
 
       ClaimResponse claim = new ClaimResponse().id("claimId").feeCode("feeCode");
 
-      when(validationContext.isFlaggedForRetry("claimId")).thenReturn(true);
+      ClaimValidationReport validationReport = new ClaimValidationReport(claim.getId());
+      validationReport.flagForRetry();
 
-      feeCalculationService.validateFeeCalculation(claim);
+      SubmissionValidationContext context = new SubmissionValidationContext();
+      context.addClaimReports(List.of(new ClaimValidationReport(claim.getId())));
+      context.flagForRetry(claim.getId());
+
+      feeCalculationService.validateFeeCalculation(claim, context);
 
       verifyNoInteractions(feeSchemeMapper);
       verifyNoInteractions(feeSchemePlatformRestClient);
+      assertThat(context.isFlaggedForRetry(claim.getId())).isTrue();
     }
   }
 }

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SubmissionValidationServiceTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SubmissionValidationServiceTest.java
@@ -119,9 +119,9 @@ public class SubmissionValidationServiceTest {
       submissionValidationService.validateSubmission(submissionId);
 
       // Then
+      verify(dataClaimsRestClient, times(1)).getSubmission(submissionId.toString());
       verify(dataClaimsRestClient, times(1))
           .updateSubmission(submissionId.toString(), submissionPatch);
-      verify(dataClaimsRestClient, times(1)).getClaim(submissionId, claimId);
       verify(providerDetailsRestClient, times(1))
           .getProviderFirmSchedules(officeAccountNumber, areaOfLaw);
       verify(claimValidationService, times(1)).validateClaims(submission, List.of(categoryOfLaw));
@@ -135,36 +135,9 @@ public class SubmissionValidationServiceTest {
       UUID submissionId = new UUID(0, 0);
       UUID claimId = new UUID(1, 1);
 
-      ClaimResponse claim = new ClaimResponse();
-      claim.id(claimId.toString());
-      claim.feeCode("feeCode");
-
-      String categoryOfLaw = "categoryOfLaw";
+      String areaOfLaw = "areaOfLaw";
       String officeAccountNumber = "officeAccountNumber";
-
-      SubmissionClaim claim = new SubmissionClaim();
-      claim.setClaimId(claimId);
-      claim.setStatus(ClaimStatus.READY_TO_PROCESS);
-
-      SubmissionResponse submission =
-          SubmissionResponse.builder()
-              .submissionId(submissionId)
-              .areaOfLaw(areaOfLaw)
-              .officeAccountNumber(officeAccountNumber)
-              .status(SubmissionStatus.READY_FOR_VALIDATION)
-              .isNilSubmission(true)
-              .claims(List.of(claim))
-              .build();
-
-      when(dataClaimsRestClient.getSubmission(submissionId.toString()))
-          .thenReturn(ResponseEntity.of(Optional.of(submission)));
-
-      ClaimResponse claimResponse = new ClaimResponse();
-      claimResponse.id(claimId.toString());
-      claimResponse.feeCode("feeCode");
-
-      when(dataClaimsRestClient.getClaim(submissionId, claimId))
-          .thenReturn(ResponseEntity.of(Optional.of(claimResponse)));
+      String categoryOfLaw = "categoryOfLaw";
 
       FirmOfficeContractAndScheduleLine scheduleLine = new FirmOfficeContractAndScheduleLine();
       scheduleLine.setCategoryOfLaw(categoryOfLaw);
@@ -175,9 +148,6 @@ public class SubmissionValidationServiceTest {
       ProviderFirmOfficeContractAndScheduleDto providerFirmResponse =
           new ProviderFirmOfficeContractAndScheduleDto();
       providerFirmResponse.addSchedulesItem(schedule);
-
-      String areaOfLaw = "areaOfLaw";
-      String officeAccountNumber = "officeAccountNumber";
 
       when(providerDetailsRestClient.getProviderFirmSchedules(officeAccountNumber, areaOfLaw))
           .thenReturn(Mono.just(providerFirmResponse));
@@ -210,15 +180,18 @@ public class SubmissionValidationServiceTest {
               .claims(List.of(submissionClaim))
               .build();
 
+      when(dataClaimsRestClient.getSubmission(submissionId.toString()))
+          .thenReturn(ResponseEntity.of(Optional.of(submission)));
+
       // When
       submissionValidationService.validateSubmission(submissionId);
 
       // Then
+      verify(dataClaimsRestClient, times(1)).getSubmission(submissionId.toString());
       verify(dataClaimsRestClient, times(1))
           .updateSubmission(submissionId.toString(), submissionPatch);
       verify(submissionValidationContext, times(1))
           .addToAllClaimReports(ClaimValidationError.INVALID_NIL_SUBMISSION_CONTAINS_CLAIMS);
-      verify(dataClaimsRestClient, times(1)).getClaim(submissionId, claimId);
       verify(providerDetailsRestClient, times(1))
           .getProviderFirmSchedules(officeAccountNumber, areaOfLaw);
       verify(claimValidationService, times(1)).validateClaims(submission, List.of(categoryOfLaw));
@@ -266,30 +239,6 @@ public class SubmissionValidationServiceTest {
       String areaOfLaw = "areaOfLaw";
       String officeAccountNumber = "officeAccountNumber";
 
-      SubmissionClaim claim = new SubmissionClaim();
-      claim.setClaimId(claimId);
-      claim.setStatus(ClaimStatus.READY_TO_PROCESS);
-      claim.feeCode("feeCode");
-
-      SubmissionResponse submission =
-          SubmissionResponse.builder()
-              .submissionId(submissionId)
-              .areaOfLaw(areaOfLaw)
-              .officeAccountNumber(officeAccountNumber)
-              .status(SubmissionStatus.READY_FOR_VALIDATION)
-              .claims(List.of(claim))
-              .build();
-
-      when(dataClaimsRestClient.getSubmission(submissionId.toString()))
-          .thenReturn(ResponseEntity.of(Optional.of(submission)));
-
-      ClaimResponse claimResponse = new ClaimResponse();
-      claimResponse.id(claimId.toString());
-      claimResponse.feeCode("feeCode");
-
-      when(dataClaimsRestClient.getClaim(submissionId, claimId))
-          .thenReturn(ResponseEntity.of(Optional.of(claimResponse)));
-
       when(providerDetailsRestClient.getProviderFirmSchedules(officeAccountNumber, areaOfLaw))
           .thenReturn(Mono.empty());
 
@@ -333,15 +282,18 @@ public class SubmissionValidationServiceTest {
               .claims(List.of(submissionClaim))
               .build();
 
+      when(dataClaimsRestClient.getSubmission(submissionId.toString()))
+          .thenReturn(ResponseEntity.of(Optional.of(submission)));
+
       // When
       submissionValidationService.validateSubmission(submissionId);
 
       // Then
+      verify(dataClaimsRestClient, times(1)).getSubmission(submissionId.toString());
       verify(dataClaimsRestClient, times(1))
           .updateSubmission(submissionId.toString(), submissionPatch);
       verify(submissionValidationContext, times(1))
           .addToAllClaimReports(ClaimValidationError.INVALID_AREA_OF_LAW_FOR_PROVIDER);
-      verify(dataClaimsRestClient, times(1)).getClaim(submissionId, claimId);
       verify(providerDetailsRestClient, times(1))
           .getProviderFirmSchedules(officeAccountNumber, areaOfLaw);
       verify(claimValidationService, times(1)).validateClaims(submission, Collections.emptyList());

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ValidationServiceTestUtils.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/ValidationServiceTestUtils.java
@@ -1,0 +1,23 @@
+package uk.gov.justice.laa.dstew.payments.claimsevent.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationError;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.ClaimValidationReport;
+import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationContext;
+
+public class ValidationServiceTestUtils {
+
+  public static void assertContextClaimError(
+      SubmissionValidationContext context,
+      String claimId,
+      ClaimValidationError claimValidationError) {
+    assertThat(context.getClaimReport(claimId))
+        .isPresent()
+        .get()
+        .extracting(ClaimValidationReport::getErrors)
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .containsExactly(claimValidationError);
+  }
+}


### PR DESCRIPTION
## Summary

[CCMSPUI-828](https://dsdmoj.atlassian.net/browse/CCMSPUI-828)

- Added duplicate checks for crime claims
- Update Data Claims API spec (see https://github.com/ministryofjustice/laa-data-claims-api/pull/50)
  - added GET /claims endpoint to support searching for duplicates
  - updated entity names to be more concise


## Checklist

Before you ask people to review this PR, please confirm:

- [x] The build pipeline is passing.
- [x] There are no conflicts with the target branch.
- [x] There are no whitespace-only changes.
- [x] There are no unexpected changes.


[CCMSPUI-828]: https://dsdmoj.atlassian.net/browse/CCMSPUI-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ