### PR TITLE
Shorten service name

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
-name: data-claims-event-service
+name: data-claims-events
 version: 0.0.0


### PR DESCRIPTION
To pass naming criteria in kubernetes:

```
Label 'uat-data-claims-event-service-***' in hostname: 
'uat-data-claims-event-service-***.apps.live.cloud-platform.service.justice.gov.uk' 
exceeds permitted length of 57 characters
```