### PR TITLE
Ignore has_assessment and version in claim response schema. Also bumped localstack version to latest free version

### DIFF
--- a/data-claims-event-service/src/main/resources/schemas/claim-fields.schema.json
+++ b/data-claims-event-service/src/main/resources/schemas/claim-fields.schema.json
@@ -1026,7 +1026,9 @@
     },
     "created_by_user_id": {
       "type": "string"
-    }
+    },
+    "has_assessment": {},
+    "version": {}
   },
   "additionalProperties": false,
   "required": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   localstack:
     container_name: event-service-localstack
-    image: localstack/localstack:3.8.1
+    image: localstack/localstack:4.14.0
     ports:
       - "4566:4566"
     environment:


### PR DESCRIPTION
## Summary

`has_assessment` and `version` are new fields in `ClaimResponse`. Due to how event service validates properties of a claim, it doesn't expect those two new fields and throws errors. This PR adds the two fields to `claim-fields.schema.json` to ignore them.

Also bumped localstack version to latest free version.

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
