### PR TITLE
[DSTEW-1538] - Removed NotNull Checks for nullable fields in Pact tests

### DIFF
--- a/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/GetSubmissionPactTest.java
+++ b/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/GetSubmissionPactTest.java
@@ -105,8 +105,6 @@ public final class GetSubmissionPactTest extends AbstractPactTest {
 
     assertThat(submission).isNotNull();
     assertThat(submission.getSubmissionId()).isEqualTo(SUBMISSION_ID);
-    assertThat(submission.getCalculatedTotalAmount()).isNotNull();
-    assertThat(submission.getAssessedTotalAmount()).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
Submission details returns calculated_total_amount as 0 instead of 0.00 - then we discovered that the field should be nullable.

https://dsdmoj.atlassian.net/browse/DSTEW-1538

Describe what you did and why. Removed the assert Not Null tests in the Pact tests for these two fields

## Checklist

Before you ask people to review this PR, please confirm:

- [x] The build pipeline is passing.
- [x] There are no conflicts with the target branch.
- [x] There are no whitespace-only changes.
- [x] There are no unexpected changes.
