### PR TITLE
[DSTEW-1538] - removed calc-total and assessed-total entirely from Pact Test and made UUIDs fixed

### DIFF
--- a/data-claims-event-service/build.gradle
+++ b/data-claims-event-service/build.gradle
@@ -42,6 +42,9 @@ repositories {
     mavenCentral()
 }
 
+// Upgrade to fix HTTP Request Smuggling (SNYK-JAVA-IONETTY-16425695)
+ext['netty.version'] = '4.2.13.Final'
+
 dependencyManagement {
     imports {
         // Upgrade to fix vulnerabilities in netty

--- a/data-claims-event-service/build.gradle
+++ b/data-claims-event-service/build.gradle
@@ -42,13 +42,10 @@ repositories {
     mavenCentral()
 }
 
-// Upgrade to fix HTTP Request Smuggling (SNYK-JAVA-IONETTY-16425695)
-ext['netty.version'] = '4.2.13.Final'
-
 dependencyManagement {
     imports {
         // Upgrade to fix vulnerabilities in netty
-        mavenBom('io.netty:netty-bom:4.2.12.Final')
+        mavenBom('io.netty:netty-bom:4.2.13.Final')
     }
     dependencies {
         dependencySet(group: 'io.sentry', version: versions.sentry) {

--- a/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/AbstractPactTest.java
+++ b/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/AbstractPactTest.java
@@ -29,11 +29,15 @@ abstract class AbstractPactTest {
   }
 
   protected static final List<String> USER_OFFICES = List.of("ABC123", "XYZ789");
-  protected static final UUID BULK_SUBMISSION_ID = UUID.randomUUID();
-  protected static final UUID SUBMISSION_ID = UUID.randomUUID();
-  protected static final UUID CLAIM_ID = UUID.randomUUID();
-  protected static final UUID CLAIM_SUMMARY_FEE_ID = UUID.randomUUID();
-  protected static final UUID MATTER_START_ID = UUID.randomUUID();
+  protected static final UUID BULK_SUBMISSION_ID =
+      UUID.fromString("00000000-0000-0000-0000-000000000001");
+  protected static final UUID SUBMISSION_ID =
+      UUID.fromString("00000000-0000-0000-0000-000000000002");
+  protected static final UUID CLAIM_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+  protected static final UUID CLAIM_SUMMARY_FEE_ID =
+      UUID.fromString("00000000-0000-0000-0000-000000000004");
+  protected static final UUID MATTER_START_ID =
+      UUID.fromString("00000000-0000-0000-0000-000000000005");
 
   protected final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/GetSubmissionPactTest.java
+++ b/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/GetSubmissionPactTest.java
@@ -105,8 +105,6 @@ public final class GetSubmissionPactTest extends AbstractPactTest {
 
     assertThat(submission).isNotNull();
     assertThat(submission.getSubmissionId()).isEqualTo(SUBMISSION_ID);
-    assertThat(submission.getCalculatedTotalAmount()).isNotNull();
-    assertThat(submission.getAssessedTotalAmount()).isNotNull();
   }
 
   @Test

--- a/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/GetSubmissionPactTest.java
+++ b/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/GetSubmissionPactTest.java
@@ -67,8 +67,6 @@ public final class GetSubmissionPactTest extends AbstractPactTest {
               body.uuid("previous_submission_id", UUID.randomUUID());
               body.booleanType("is_nil_submission", true);
               body.numberType("number_of_claims", 0);
-              body.numberType("calculated_total_amount", 0);
-              body.numberType("assessed_total_amount", 0);
               body.datetime("submitted", "yyyy-MM-dd'T'HH:mm:ssXXX");
               body.stringType("created_by_user_id", "string");
               body.minArrayLike(


### PR DESCRIPTION
## Summary

https://dsdmoj.atlassian.net/browse/DSTEW-1538

Removed calc-total and assessed-total entirely from Pact Test and made UUIDs fixed
Bumped a vulnerability

## Checklist

Before you ask people to review this PR, please confirm:

- [x] The build pipeline is passing.
- [x] There are no conflicts with the target branch.
- [x] There are no whitespace-only changes.
- [x] There are no unexpected changes.
