### PR TITLE
feat: Enable graceful shutdown for SQS message processing

### DIFF
--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/listener/SubmissionListener.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/listener/SubmissionListener.java
@@ -78,6 +78,8 @@ public class SubmissionListener {
       extender.start(receiptHandle);
       SubmissionEventType submissionEventType = getSubmissionEventType(message);
       processMessageByType(message, submissionEventType);
+      // calls extender.markCompleted() just before the try-with-resources exits normally
+      extender.markCompleted();
     } catch (SubmissionEventProcessingException | IllegalArgumentException ex) {
       throw ex;
     } catch (Exception ex) {

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SqsVisibilityExtender.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/service/SqsVisibilityExtender.java
@@ -29,6 +29,7 @@ public class SqsVisibilityExtender implements AutoCloseable {
   private ScheduledFuture<?> scheduledTask;
   private String receiptHandle;
   private String queueUrl;
+  private boolean completed;
 
   /**
    * Constructs an instance of SqsVisibilityExtender.
@@ -51,6 +52,14 @@ public class SqsVisibilityExtender implements AutoCloseable {
     this.visibilityExtensionIntervalSeconds = visibilityExtensionIntervalSeconds;
     this.scheduler = Executors.newScheduledThreadPool(1);
     this.queueName = queueName;
+  }
+
+  /**
+   * Marks processing as successfully completed so that {@link #close()} does not reset the message
+   * visibility. Call this immediately before the try-with-resources block exits normally.
+   */
+  public void markCompleted() {
+    this.completed = true;
   }
 
   /**
@@ -98,5 +107,33 @@ public class SqsVisibilityExtender implements AutoCloseable {
       scheduledTask.cancel(true);
     }
     scheduler.shutdownNow();
+    try {
+      scheduler.awaitTermination(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    if (!completed && receiptHandle != null && queueUrl != null) {
+      /*
+       * resets the SQS message visibility to 0 if processing did not complete normally
+       */
+      try {
+        log.debug(
+            "Processing did not complete normally; resetting SQS visibility to 0 for"
+                + " receiptHandle={}",
+            receiptHandle);
+        sqsClient.changeMessageVisibility(
+            ChangeMessageVisibilityRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(receiptHandle)
+                .visibilityTimeout(0)
+                .build());
+      } catch (Exception ex) {
+        log.warn(
+            "Failed to reset SQS visibility for receiptHandle={}: {}",
+            receiptHandle,
+            ex.getMessage());
+      }
+    }
   }
 }

--- a/data-claims-event-service/src/main/resources/application.yml
+++ b/data-claims-event-service/src/main/resources/application.yml
@@ -6,10 +6,17 @@ spring:
     virtual:
       enabled: true
 
+  lifecycle:
+    # a conservative starting point - this is the total time for the application to shut down
+    timeout-per-shutdown-phase: 10m
+
   cloud:
     aws:
       sqs:
         queue-not-found-strategy: fail
+        listener:
+          max-concurrent-messages: 3
+          max-messages-per-poll: 3
       region:
         static: ${AWS_REGION}
 
@@ -37,6 +44,7 @@ info:
 
 server:
   port: 8085
+  shutdown: graceful
 
 management:
   server:
@@ -52,6 +60,8 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
 
 sentry:
   dsn: ${SENTRY_DSN:}

--- a/helm-chart/templates/application-deployment-library.yaml
+++ b/helm-chart/templates/application-deployment-library.yaml
@@ -19,6 +19,7 @@ spec:
         app: {{ .Release.Name }}-{{ .Chart.Name }}-pod
         app.kubernetes.io/name: {{ .Release.Name }}-{{ .Chart.Name }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.shutdown.terminationGracePeriodSeconds | default 660 }}
       serviceAccountName: {{ .Values.serviceAccountName }}
       {{- if .Values.securityContext }}
       securityContext:
@@ -138,6 +139,10 @@ spec:
             initialDelaySeconds: 10
             {{- end }}
           {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "{{ .Values.shutdown.preStopSleepSeconds | default 5 }}"]
           env:
           {{- if .Values.env }}
           {{- range .Values.env }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -114,6 +114,12 @@ resources:
     cpu: 25m
     memory: 1G
 
+shutdown:
+  # Must be greater than spring.lifecycle.timeout-per-shutdown-phase (10m / 600s) to allow in-flight work to finish
+  terminationGracePeriodSeconds: 660
+  # Short sleep to allow the readiness probe state to propagate before SIGTERM processing begins
+  preStopSleepSeconds: 5
+
 sentry:
   enabled: true
   environment: production


### PR DESCRIPTION
## Summary

### Problem
During rolling deployments, pods are terminated immediately without waiting for in-flight SQS messages to finish processing. This can leave messages in an invisible state on the queue for up to 10 minutes (the visibility timeout) before they become available for retry — causing unnecessary delays and potential data inconsistency.

### What this PR cannot do
The definitive proof that a rolling deployment won't interrupt in-flight work ideally needs a Kubernetes environment where we can observe a message completing during a pod termination.

### What this PR does
Implements graceful shutdown across three layers so that in-flight SQS messages complete processing before a pod is killed, and any interrupted messages are made immediately re-available.

**Spring Boot (`application.yml`)**
- server.shutdown: graceful — stops accepting new work on SIGTERM and waits for in-flight listeners to finish
- spring.lifecycle.timeout-per-shutdown-phase: 10m — maximum drain time for in-flight SQS message processing
- management.endpoint.health.probes.enabled: true — exposes liveness/readiness probe endpoints so Kubernetes can detect shutdown state
- Configured SQS listener concurrency (max-concurrent-messages: 3, max-messages-per-poll: 3)

**Kubernetes / Helm**
- terminationGracePeriodSeconds: 660 — gives K8s enough time (preStop 5s + Spring 600s + 55s buffer) before sending SIGKILL
- preStop: sleep 5 — allows readiness probe failure to propagate to endpoints before SIGTERM processing begins

**Application (`SqsVisibilityExtender`)**
- Added markCompleted() flag — called after successful message processing
- On close(), if processing did not complete (exception or shutdown), resets the SQS message visibility to 0, making it immediately re-available for another consumer instead of waiting for the full visibility timeout to expire
- Added awaitTermination to cleanly shut down the visibility extension scheduler

**Shutdown sequence**
```
K8s marks pod Terminating
  → preStop: sleep 5s (readiness propagation)
  → SIGTERM → Spring stops SQS polling
  → In-flight listeners drain (up to 10m)
  → Spring context closes
  → If still alive after 660s: SIGKILL
```

## TODO
- [ ] Test, test and test

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
