### PR TITLE
BC-450 | Updated init-localstack.sh to create second notify queue for fan out

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,11 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+#
+ignore:
+  SNYK-JAVA-ORGSPRINGFRAMEWORKRETRY-17260993:
+    - '*':
+        reason: Allocation of Resources Without Limits or Throttling in spring-retry; awaiting upgrade to 2.0.13
+        expires: 2026-06-26T00:00:00.000Z
+
+patch: {}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.1.0'
-    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.2.6' apply false
+    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.2.12' apply false
 }
 
 subprojects {

--- a/data-claims-event-service/build.gradle
+++ b/data-claims-event-service/build.gradle
@@ -43,12 +43,11 @@ repositories {
 }
 
 ext['tomcat.version'] = '11.0.22'
-ext['netty.version'] = '4.2.15.Final'
 
 dependencyManagement {
     imports {
         // Upgrade to fix vulnerabilities in netty
-        mavenBom('io.netty:netty-bom:4.2.13.Final')
+        mavenBom('io.netty:netty-bom:4.2.15.Final')
     }
     dependencies {
         dependencySet(group: 'io.sentry', version: versions.sentry) {

--- a/data-claims-event-service/build.gradle
+++ b/data-claims-event-service/build.gradle
@@ -43,6 +43,7 @@ repositories {
 }
 
 ext['tomcat.version'] = '11.0.22'
+ext['netty.version'] = '4.2.15.Final'
 
 dependencyManagement {
     imports {

--- a/docker-scripts/init-localstack.sh
+++ b/docker-scripts/init-localstack.sh
@@ -17,14 +17,26 @@ done
 echo "Initializing localstack SNS"
 TOPIC_ARN=$(awslocal sns create-topic --name claims-events --query 'TopicArn' --output text)
 
-echo "Initializing localstack SNS"
-TOPIC_ARN=$(awslocal sns create-topic --name claims-events --query 'TopicArn' --output text)
-
 echo "Initializing localstack SQS"
 
-QUEUE_URL=$(awslocal sqs create-queue --queue-name claims-api-queue --attributes VisibilityTimeout=1200 --query 'QueueUrl' --output text)
-QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url $QUEUE_URL --attribute-name QueueArn --query 'Attributes.QueueArn' --output text)
+CLAIMS_QUEUE_URL=$(awslocal sqs create-queue --queue-name claims-api-queue --attributes VisibilityTimeout=1200 --query 'QueueUrl' --output text)
+CLAIMS_QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url $CLAIMS_QUEUE_URL --attribute-name QueueArn --query 'Attributes.QueueArn' --output text)
+
+echo "Creating notify-queue"
+NOTIFY_QUEUE_URL=$(awslocal sqs create-queue --queue-name notify-queue --attributes VisibilityTimeout=1200 --query 'QueueUrl' --output text)
+NOTIFY_QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url $NOTIFY_QUEUE_URL --attribute-name QueueArn --query 'Attributes.QueueArn' --output text)
 
 echo "Subscribing queue to topic"
+awslocal sns subscribe \
+  --topic-arn $TOPIC_ARN \
+  --protocol sqs \
+  --notification-endpoint $CLAIMS_QUEUE_ARN \
+  --attributes '{"RawMessageDelivery":"true","FilterPolicy":"{\"SubmissionEventType\":[\"PARSE_BULK_SUBMISSION\",\"VALIDATE_SUBMISSION\"]}"}'
+# ,FilterPolicy='{"SubmissionEventType":["PARSE_BULK_SUBMISSION", "VALIDATE_SUBMISSION"]}'
 
-awslocal sns subscribe --topic-arn $TOPIC_ARN --protocol sqs --notification-endpoint $QUEUE_ARN --attributes RawMessageDelivery=true
+echo "Subscribing notify-queue to topic with filter policy"
+awslocal sns subscribe \
+  --topic-arn $TOPIC_ARN \
+  --protocol sqs \
+  --notification-endpoint $NOTIFY_QUEUE_ARN \
+  --attributes '{"RawMessageDelivery":"true","FilterPolicy":"{\"SubmissionEventType\":[\"SUBMISSION_VALIDATION_SUCCEEDED\"]}"}'

--- a/reference-fee-scheme-platform-api/build.gradle
+++ b/reference-fee-scheme-platform-api/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.openapi.generator' version '7.14.0'
-    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.2.6'
+    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.2.12'
 }
 
 repositories {


### PR DESCRIPTION
## Summary
Currently the localstack instance doesn't contain two queues. For our production environment, we have a fan out procedure where submissions go to either the claims queue or notify queue depending on if the message pushed contains a specific submission status.

[Link to story](https://dsdmoj.atlassian.net/browse/BC-450)

Describe what you did and why.

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
