### PR TITLE
Added `sharing=locked` to Dockerfile_internal to ensure cache sharing is locked for concurrent local Docker builds.

### DIFF
--- a/Dockerfile_internal
+++ b/Dockerfile_internal
@@ -10,7 +10,7 @@ COPY . .
 RUN env
 
 # Run gradle build
-RUN --mount=type=cache,target=/root/.gradle \
+RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
     --mount=type=secret,id=github_actor \
     --mount=type=secret,id=github_token \
     export GITHUB_ACTOR="$(cat /run/secrets/github_actor)" && \


### PR DESCRIPTION
## Summary
Concurrent Docker builds don't work when running at the same time, and has become more of a problem the more services which are building at the same time. This fixes that issue:
```
 > [event-service builder 5/6] RUN --mount=type=cache,target=/root/.gradle     --mount=type=secret,id=github_actor     --mount=type=secret,id=github_token     export GITHUB_ACTOR="$(cat /run/secrets/github_actor)" &&     export GITHUB_TOKEN="$(cat /run/secrets/github_token)" &&     gradle assemble:
1.902
1.902 Welcome to Gradle 9.5.1!
1.902
1.902 Here are the highlights of this release:
1.902  - Task provenance in reports and failure messages
1.902  - Type-safe accessors for precompiled Kotlin Settings plugins
1.902
1.902 For more details see https://docs.gradle.org/9.5.1/release-notes.html
1.902
2.101 Starting a Gradle Daemon (subsequent builds will be faster)
65.71
65.71 FAILURE: Build failed with an exception.
65.71
65.71 * What went wrong:
65.71 Gradle could not start your build.
65.71 > Cannot create service of type BuildSessionActionExecutor using method LauncherServices$ToolingBuildSessionScopeServices.createActionExecutor() as there is a problem with parameter #21 of type BuildLifecycleAwareVirtualFileSystem.
65.71    > Cannot create service of type BuildLifecycleAwareVirtualFileSystem using method VirtualFileSystemServices$GradleUserHomeServices.createVirtualFileSystem() as there is a problem with parameter #1 of type FileWatchingFilter.
65.71       > Cannot create service of type FileWatchingFilter using method VirtualFileSystemServices$GradleUserHomeServices.createFileWatchingFilter() as there is a problem with parameter #1 of type GlobalCacheLocations.
65.71          > Cannot create service of type GlobalCacheLocations using method GradleUserHomeScopeServices.createGlobalCacheLocations() as there is a problem with parameter #1 of type List<GlobalCache>.
65.71             > Could not create service of type FileAccessTimeJournal using GradleUserHomeScopeServices.createFileAccessTimeJournal().
65.71                > Timeout waiting to lock journal cache (/home/gradle/.gradle/caches/journal-1). It is currently in use by another process.
65.71                  Owner PID: 48
65.71                  Our PID: 47
65.71                  Owner Operation:
65.71                  Our operation:
65.71                  Lock file: /home/gradle/.gradle/caches/journal-1/journal-1.lock
65.71
65.71 * Try:
65.71 > Run with --stacktrace option to get the stack trace.
65.71 > Run with --info or --debug option to get more log output.
65.71 > Run with --scan to get full insights from a Build Scan (powered by Develocity).
65.71 > Get more help at https://help.gradle.org.
65.71
65.71 BUILD FAILED in 1m 5s
```
 

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
