### PR TITLE
fix pact test 

### DIFF
--- a/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/PostSubmissionPactTest.java
+++ b/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/PostSubmissionPactTest.java
@@ -42,7 +42,7 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
 
   @SneakyThrows
   @Pact(consumer = CONSUMER)
-  RequestResponsePact postSubmission201ReadyForValidationStatus(PactDslWithProvider builder) {
+  RequestResponsePact postSubmission201(PactDslWithProvider builder) {
     // Defines expected 201 response for successfully submitting valid submission using matchers
     return builder
         .given("the system is ready to process a valid submission")
@@ -79,8 +79,8 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
 
   @Test
   @DisplayName("Verify 201 response")
-  @PactTestFor(pactMethod = "postSubmission201CreatedStatus")
-  void verify201ResponseCreatedStatus() {
+  @PactTestFor(pactMethod = "postSubmission201")
+  void verify201Response() {
     SubmissionPost submissionPost = getSubmissionPost();
 
     ResponseEntity<CreateSubmission201Response> response =
@@ -88,14 +88,6 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
     assertThat(response).isNotNull();
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(response.getBody().getId()).isEqualTo(SUBMISSION_ID);
-  }
-
-  @Test
-  @DisplayName("Verify 400 response")
-  @PactTestFor(pactMethod = "postSubmission400")
-  void verify400Response() {
-    SubmissionPost submissionPost = getSubmissionPost();
-    assertThrows(BadRequest.class, () -> dataClaimsRestClient.createSubmission(submissionPost));
   }
 
   private SubmissionPost getSubmissionPost() {
@@ -109,5 +101,13 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
         .providerUserId("test-user")
         .status(SubmissionStatus.CREATED)
         .createdByUserId("test-user");
+  }
+
+  @Test
+  @DisplayName("Verify 400 response")
+  @PactTestFor(pactMethod = "postSubmission400")
+  void verify400Response() {
+    SubmissionPost submissionPost = getSubmissionPost();
+    assertThrows(BadRequest.class, () -> dataClaimsRestClient.createSubmission(submissionPost));
   }
 }

--- a/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/PostSubmissionPactTest.java
+++ b/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/PostSubmissionPactTest.java
@@ -42,26 +42,6 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
 
   @SneakyThrows
   @Pact(consumer = CONSUMER)
-  RequestResponsePact postSubmission201CreatedStatus(PactDslWithProvider builder) {
-    // Defines expected 201 response for successfully submitting valid submission using matchers
-    return builder
-        .given(
-            "the system is ready to process a submission with created status without pre-validation")
-        .uponReceiving("a new submission request")
-        .path("/api/v1/submissions")
-        .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX, EXAMPLE_AUTH_TOKEN)
-        .method("POST")
-        .body(objectMapper.writeValueAsString(getSubmissionPostCreatedStatus()))
-        .matchHeader("Content-Type", "application/json")
-        .willRespondWith()
-        .status(201)
-        .headers(Map.of("Content-Type", "application/json"))
-        .body(LambdaDsl.newJsonBody(body -> body.uuid("id", SUBMISSION_ID)).build())
-        .toPact();
-  }
-
-  @SneakyThrows
-  @Pact(consumer = CONSUMER)
   RequestResponsePact postSubmission201ReadyForValidationStatus(PactDslWithProvider builder) {
     // Defines expected 201 response for successfully submitting valid submission using matchers
     return builder
@@ -70,7 +50,7 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
         .path("/api/v1/submissions")
         .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX, EXAMPLE_AUTH_TOKEN)
         .method("POST")
-        .body(objectMapper.writeValueAsString(getSubmissionPostReadyForValidationStatus()))
+        .body(objectMapper.writeValueAsString(getSubmissionPost()))
         .matchHeader("Content-Type", "application/json")
         .willRespondWith()
         .status(201)
@@ -89,7 +69,7 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
         .path("/api/v1/submissions")
         .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX, EXAMPLE_AUTH_TOKEN)
         .method("POST")
-        .body(objectMapper.writeValueAsString(getSubmissionPostReadyForValidationStatus()))
+        .body(objectMapper.writeValueAsString(getSubmissionPost()))
         .matchHeader("Content-Type", "application/json")
         .willRespondWith()
         .status(400)
@@ -101,20 +81,7 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
   @DisplayName("Verify 201 response")
   @PactTestFor(pactMethod = "postSubmission201CreatedStatus")
   void verify201ResponseCreatedStatus() {
-    SubmissionPost submissionPost = getSubmissionPostCreatedStatus();
-
-    ResponseEntity<CreateSubmission201Response> response =
-        dataClaimsRestClient.createSubmission(submissionPost);
-    assertThat(response).isNotNull();
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-    assertThat(response.getBody().getId()).isEqualTo(SUBMISSION_ID);
-  }
-
-  @Test
-  @DisplayName("Verify 201 response")
-  @PactTestFor(pactMethod = "postSubmission201ReadyForValidationStatus")
-  void verify201ResponseReadyForValidationStatus() {
-    SubmissionPost submissionPost = getSubmissionPostReadyForValidationStatus();
+    SubmissionPost submissionPost = getSubmissionPost();
 
     ResponseEntity<CreateSubmission201Response> response =
         dataClaimsRestClient.createSubmission(submissionPost);
@@ -127,26 +94,11 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
   @DisplayName("Verify 400 response")
   @PactTestFor(pactMethod = "postSubmission400")
   void verify400Response() {
-    SubmissionPost submissionPost = getSubmissionPostReadyForValidationStatus();
+    SubmissionPost submissionPost = getSubmissionPost();
     assertThrows(BadRequest.class, () -> dataClaimsRestClient.createSubmission(submissionPost));
   }
 
-  private SubmissionPost getSubmissionPostReadyForValidationStatus() {
-    return new SubmissionPost()
-        .bulkSubmissionId(BULK_SUBMISSION_ID)
-        .submissionId(SUBMISSION_ID)
-        .submissionPeriod("APR-2025")
-        .areaOfLaw(AreaOfLaw.LEGAL_HELP)
-        .numberOfClaims(0)
-        .officeAccountNumber("ABC123")
-        .providerUserId("test-user")
-        .isNilSubmission(true)
-        .legalHelpSubmissionReference("123ABC")
-        .status(SubmissionStatus.READY_FOR_VALIDATION)
-        .createdByUserId("test-user");
-  }
-
-  private SubmissionPost getSubmissionPostCreatedStatus() {
+  private SubmissionPost getSubmissionPost() {
     return new SubmissionPost()
         .bulkSubmissionId(BULK_SUBMISSION_ID)
         .submissionId(SUBMISSION_ID)

--- a/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/PostSubmissionPactTest.java
+++ b/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/PostSubmissionPactTest.java
@@ -96,7 +96,7 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
         .submissionId(SUBMISSION_ID)
         .submissionPeriod("APR-2025")
         .areaOfLaw(AreaOfLaw.LEGAL_HELP)
-        .numberOfClaims(0)
+        .numberOfClaims(2)
         .officeAccountNumber("ABC123")
         .providerUserId("test-user")
         .status(SubmissionStatus.CREATED)

--- a/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/PostSubmissionPactTest.java
+++ b/data-claims-event-service/src/pactTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/dataclaimsapi/PostSubmissionPactTest.java
@@ -42,7 +42,27 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
 
   @SneakyThrows
   @Pact(consumer = CONSUMER)
-  RequestResponsePact postSubmission201(PactDslWithProvider builder) {
+  RequestResponsePact postSubmission201CreatedStatus(PactDslWithProvider builder) {
+    // Defines expected 201 response for successfully submitting valid submission using matchers
+    return builder
+        .given(
+            "the system is ready to process a submission with created status without pre-validation")
+        .uponReceiving("a new submission request")
+        .path("/api/v1/submissions")
+        .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX, EXAMPLE_AUTH_TOKEN)
+        .method("POST")
+        .body(objectMapper.writeValueAsString(getSubmissionPostCreatedStatus()))
+        .matchHeader("Content-Type", "application/json")
+        .willRespondWith()
+        .status(201)
+        .headers(Map.of("Content-Type", "application/json"))
+        .body(LambdaDsl.newJsonBody(body -> body.uuid("id", SUBMISSION_ID)).build())
+        .toPact();
+  }
+
+  @SneakyThrows
+  @Pact(consumer = CONSUMER)
+  RequestResponsePact postSubmission201ReadyForValidationStatus(PactDslWithProvider builder) {
     // Defines expected 201 response for successfully submitting valid submission using matchers
     return builder
         .given("the system is ready to process a valid submission")
@@ -50,7 +70,7 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
         .path("/api/v1/submissions")
         .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX, EXAMPLE_AUTH_TOKEN)
         .method("POST")
-        .body(objectMapper.writeValueAsString(getSubmissionPost()))
+        .body(objectMapper.writeValueAsString(getSubmissionPostReadyForValidationStatus()))
         .matchHeader("Content-Type", "application/json")
         .willRespondWith()
         .status(201)
@@ -69,7 +89,7 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
         .path("/api/v1/submissions")
         .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX, EXAMPLE_AUTH_TOKEN)
         .method("POST")
-        .body(objectMapper.writeValueAsString(getSubmissionPost()))
+        .body(objectMapper.writeValueAsString(getSubmissionPostReadyForValidationStatus()))
         .matchHeader("Content-Type", "application/json")
         .willRespondWith()
         .status(400)
@@ -79,9 +99,9 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
 
   @Test
   @DisplayName("Verify 201 response")
-  @PactTestFor(pactMethod = "postSubmission201")
-  void verify201Response() {
-    SubmissionPost submissionPost = getSubmissionPost();
+  @PactTestFor(pactMethod = "postSubmission201CreatedStatus")
+  void verify201ResponseCreatedStatus() {
+    SubmissionPost submissionPost = getSubmissionPostCreatedStatus();
 
     ResponseEntity<CreateSubmission201Response> response =
         dataClaimsRestClient.createSubmission(submissionPost);
@@ -90,24 +110,52 @@ public final class PostSubmissionPactTest extends AbstractPactTest {
     assertThat(response.getBody().getId()).isEqualTo(SUBMISSION_ID);
   }
 
-  private SubmissionPost getSubmissionPost() {
-    return new SubmissionPost()
-        .bulkSubmissionId(BULK_SUBMISSION_ID)
-        .submissionId(SUBMISSION_ID)
-        .submissionPeriod("APR-2025")
-        .areaOfLaw(AreaOfLaw.LEGAL_HELP)
-        .numberOfClaims(2)
-        .officeAccountNumber("ABC123")
-        .providerUserId("test-user")
-        .status(SubmissionStatus.READY_FOR_VALIDATION)
-        .createdByUserId("test-user");
+  @Test
+  @DisplayName("Verify 201 response")
+  @PactTestFor(pactMethod = "postSubmission201ReadyForValidationStatus")
+  void verify201ResponseReadyForValidationStatus() {
+    SubmissionPost submissionPost = getSubmissionPostReadyForValidationStatus();
+
+    ResponseEntity<CreateSubmission201Response> response =
+        dataClaimsRestClient.createSubmission(submissionPost);
+    assertThat(response).isNotNull();
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getBody().getId()).isEqualTo(SUBMISSION_ID);
   }
 
   @Test
   @DisplayName("Verify 400 response")
   @PactTestFor(pactMethod = "postSubmission400")
   void verify400Response() {
-    SubmissionPost submissionPost = getSubmissionPost();
+    SubmissionPost submissionPost = getSubmissionPostReadyForValidationStatus();
     assertThrows(BadRequest.class, () -> dataClaimsRestClient.createSubmission(submissionPost));
+  }
+
+  private SubmissionPost getSubmissionPostReadyForValidationStatus() {
+    return new SubmissionPost()
+        .bulkSubmissionId(BULK_SUBMISSION_ID)
+        .submissionId(SUBMISSION_ID)
+        .submissionPeriod("APR-2025")
+        .areaOfLaw(AreaOfLaw.LEGAL_HELP)
+        .numberOfClaims(0)
+        .officeAccountNumber("ABC123")
+        .providerUserId("test-user")
+        .isNilSubmission(true)
+        .legalHelpSubmissionReference("123ABC")
+        .status(SubmissionStatus.READY_FOR_VALIDATION)
+        .createdByUserId("test-user");
+  }
+
+  private SubmissionPost getSubmissionPostCreatedStatus() {
+    return new SubmissionPost()
+        .bulkSubmissionId(BULK_SUBMISSION_ID)
+        .submissionId(SUBMISSION_ID)
+        .submissionPeriod("APR-2025")
+        .areaOfLaw(AreaOfLaw.LEGAL_HELP)
+        .numberOfClaims(0)
+        .officeAccountNumber("ABC123")
+        .providerUserId("test-user")
+        .status(SubmissionStatus.CREATED)
+        .createdByUserId("test-user");
   }
 }


### PR DESCRIPTION
## Summary

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)

This pr is because of changes implemented in claims api as part of BC-572 to add new validation package when submission status is not created (meaning that it is a form nil submission as other submission going through event service get a status of created). Therefore, any submissions with status different to created would get pre-validated and this pact test will fail.

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
