### PR TITLE
chore(DSTEW-1991): bump log4j to 2.25.5 to fix the vulnerability repo…

### DIFF
--- a/data-claims-event-service/build.gradle
+++ b/data-claims-event-service/build.gradle
@@ -63,6 +63,8 @@ dependencyManagement {
         dependency "com.fasterxml.jackson.core:jackson-databind:2.21.5"
         dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.23'
         dependency 'org.springframework.retry:spring-retry:2.0.13'
+        // Bump Log4j API to resolve Snyk issue (upgrade from 2.25.4 -> 2.25.5)
+        dependency "org.apache.logging.log4j:log4j-api:2.25.5"
     }
 }
 


### PR DESCRIPTION

## Summary

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1991)

DSTEW-1991: bump log4j to 2.25.5 to fix the vulnerability reported by Snyk

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
