### PR TITLE
ci(DSTEW-2040): Update to commons 3.0 and use maven central

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Summary
 
-[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)
+[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-XXXX)
 
 Describe what you did and why.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,17 @@
 plugins {
-    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.2.12' apply false
+    id 'uk.gov.justice.service.laa.laa-spring-boot-gradle-plugin' version '3.0.0' apply false
 }
 
 subprojects {
     group = 'uk.gov.justice.laa.dstew.payments.claimsevent'
+
+    // Centralised Checkstyle version for all modules.
+    // Applied in afterEvaluate so it overrides the default set by the laa-spring-boot-gradle-plugin.
+    plugins.withId('checkstyle') {
+        afterEvaluate {
+            checkstyle {
+                toolVersion = '11.0.0'
+            }
+        }
+    }
 }

--- a/data-claims-event-service/build.gradle
+++ b/data-claims-event-service/build.gradle
@@ -43,7 +43,7 @@ ext['tomcat.version'] = '11.0.23' // bumped patch release to address Snyk tomcat
 dependencyManagement {
     imports {
         // Upgrade to fix vulnerabilities in netty
-        mavenBom('io.netty:netty-bom:4.2.15.Final')
+        mavenBom('io.netty:netty-bom:4.2.16.Final')
     }
     dependencies {
         dependencySet(group: 'io.sentry', version: versions.sentry) {

--- a/data-claims-event-service/build.gradle
+++ b/data-claims-event-service/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'uk.gov.justice.service.laa.laa-spring-boot-gradle-plugin'
     id 'io.freefair.lombok' version '9.2.0'
     id("com.diffplug.spotless") version "7.2.1"
     id "io.sentry.jvm.gradle" version "5.12.2"
@@ -11,11 +12,6 @@ def versions = [
         jackson : '2.21.5' // bumped to patch release to address Snyk jackson-databind finding
 ]
 
-apply plugin: 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin'
-
-checkstyle {
-    toolVersion = '11.0.0'
-}
 
 test {
     useJUnitPlatform()
@@ -41,10 +37,6 @@ jacocoTestCoverageVerification {
     }
 }
 
-repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
-}
 
 ext['tomcat.version'] = '11.0.23' // bumped patch release to address Snyk tomcat-embed findings
 
@@ -244,7 +236,6 @@ pact {
 
     }
 }
-
 
 testlogger {
     theme 'mocha'

--- a/reference-fee-scheme-platform-api/build.gradle
+++ b/reference-fee-scheme-platform-api/build.gradle
@@ -1,15 +1,8 @@
 plugins {
     id 'org.openapi.generator' version '7.14.0'
-    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.2.12'
+    id 'uk.gov.justice.service.laa.laa-spring-boot-gradle-plugin'
 }
 
-repositories {
-    mavenCentral()
-}
-
-checkstyle {
-    toolVersion = '11.0.0'
-}
 
 dependencyManagement {
     dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,15 +1,8 @@
 pluginManagement {
     repositories {
-        maven {
-            name = "gitHubPackages"
-            url uri('https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common')
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")?.trim() ?: settings.ext.find('project.ext.gitPackageUser')
-                password = System.getenv("GITHUB_TOKEN")?.trim() ?: settings.ext.find('project.ext.gitPackageKey')
-            }
-        }
         maven { url "https://plugins.gradle.org/m2/" }
         gradlePluginPortal()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
## Summary

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2040)

Migrate to laa-spring-boot-common v3.0.0, which moves the LAA Gradle plugins and libraries from GitHub Packages to Maven Central.
### Changes

- settings.gradle - Removed the GitHub Packages pluginManagement repository for laa-spring-boot-common and its credentials (gitPackageUser/gitPackageKey, GITHUB_ACTOR/GITHUB_TOKEN). Added mavenCentral() so the plugin resolves from Maven Central.
- Plugin ID + version - Renamed uk.gov.laa.springboot.laa-spring-boot-gradle-plugin → uk.gov.justice.service.laa.laa-spring-boot-gradle-plugin and bumped 2.2.12 → 3.0.0. The version is now declared once in the root build.gradle (apply false); both submodules reference the plugin id without a version.
- data-claims-event-service/build.gradle - Moved the plugin into the plugins {} block (removed the standalone apply plugin: line) and removed the redundant repositories { mavenCentral() } (provided by the plugin).
- reference-fee-scheme-platform-api/build.gradle - Applied the same plugin id/version inheritance and removed the redundant repositories { mavenCentral() }.
- Checkstyle — Centralised toolVersion = '11.0.0' into the root build.gradle subprojects block (removed the duplicated blocks from both modules).

## Checklist

Before you ask people to review this PR, please confirm:

- [x] The build pipeline is passing.
- [x] There are no conflicts with the target branch.
- [x] There are no whitespace-only changes.
- [x] There are no unexpected changes.
