### PR TITLE
chore: bump devsecop-hook to v2.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,6 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.3.0
+    rev: 53d252e406bae2bbbd0c0f3205b72870a02c9b3f # v2.0.2
     hooks:
       - id: baseline

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -12,6 +12,10 @@ curl --proto '=https' --tlsv1.2 \
 echo "\nInstalling prek within the repository"
 prek install
 
+# Install gitleaks
+echo "\nInstalling gitleaks"
+brew install gitleaks
+
 echo "Git hooks setup complete!"
 echo "The pre-commit hook will now:"
 echo "  1. Run Spotless formatting on staged Java files"


### PR DESCRIPTION
## Summary

Describe what you did and why.

Bumping `devsecops-hooks` version that now includes gitleaks.
Install `gitleaks` as the hook no longer runs in Docker.

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
