### PR TITLE
fix(DSTEW-1929): Fix submission-level duplicate check to catch in-flight duplicates

### DIFF
--- a/data-claims-event-service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimRestClientIntTest.java
+++ b/data-claims-event-service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/client/DataClaimRestClientIntTest.java
@@ -3,7 +3,6 @@ package uk.gov.justice.laa.dstew.payments.claimsevent.client;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -56,6 +55,6 @@ public class DataClaimRestClientIntTest extends MockServerIntegrationTest {
 
     assertThat(actualResults.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(actualResults.getBody().getContent().get(0).getSubmissionId())
-        .isEqualTo(UUID.fromString("0561d67b-30ed-412e-8231-f6296a53538d"));
+        .isEqualTo(EXISTING_DUPLICATE_SUBMISSION_ID);
   }
 }

--- a/data-claims-event-service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/helper/MockServerIntegrationTest.java
+++ b/data-claims-event-service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/helper/MockServerIntegrationTest.java
@@ -67,6 +67,14 @@ public abstract class MockServerIntegrationTest {
   private static final String FEE_CALCULATION = API_VERSION_1 + "fee-calculation";
   private static final String CLAIMS_ENDPOINT = "/claims/";
 
+  /**
+   * Submission id of the earlier, in-flight duplicate returned by {@code
+   * get-submissions-by-filter.json}. Shared so tests that assert on the fixture and tests that
+   * exercise the duplicate check stay in sync.
+   */
+  protected static final UUID EXISTING_DUPLICATE_SUBMISSION_ID =
+      UUID.fromString("11111111-1111-1111-1111-111111111111");
+
   protected static final DockerImageName MOCKSERVER_IMAGE =
       DockerImageName.parse("mockserver/mockserver")
           .withTag("mockserver-" + MockServerClient.class.getPackage().getImplementationVersion());

--- a/data-claims-event-service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/validator/SubmissionValidationServiceIntegrationTest.java
+++ b/data-claims-event-service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/validator/SubmissionValidationServiceIntegrationTest.java
@@ -44,8 +44,8 @@ import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValida
 public class SubmissionValidationServiceIntegrationTest extends MockServerIntegrationTest {
 
   private static final String OFFICE_CODE = "AQ2B3C";
-  private static final AreaOfLaw AREA_OF_LAW = AreaOfLaw.LEGAL_HELP;
-  public static final String SUBMISSION_PERIOD = "submission_period";
+  private static final AreaOfLaw LEGAL_HELP = AreaOfLaw.LEGAL_HELP;
+  public static final String SUBMISSION_PERIOD_PARAM = "submission_period";
   public static final String SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON =
       "data-claims/get-submission/get-submissions-by-filter_no_content.json";
 
@@ -60,8 +60,8 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
   @DisplayName("Submission period tests")
   class SubmissionPeriodTests {
 
-    public static final String OFFICES = "offices";
-    public static final String AREA_OF_LAW1 = "area_of_law";
+    public static final String OFFICES_PARAM = "offices";
+    public static final String AREA_OF_LAW_PARAM = "area_of_law";
     public static final String APR_2025 = "APR-2025";
 
     @Test
@@ -75,9 +75,9 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param(OFFICES, OFFICE_CODE),
-              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
-              Parameter.param(SUBMISSION_PERIOD, APR_2025)),
+              Parameter.param(OFFICES_PARAM, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW_PARAM, LEGAL_HELP.name()),
+              Parameter.param(SUBMISSION_PERIOD_PARAM, APR_2025)),
           SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When
@@ -98,9 +98,9 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param(OFFICES, OFFICE_CODE),
-              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
-              Parameter.param(SUBMISSION_PERIOD, "MAR-2025")),
+              Parameter.param(OFFICES_PARAM, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW_PARAM, LEGAL_HELP.name()),
+              Parameter.param(SUBMISSION_PERIOD_PARAM, "MAR-2025")),
           SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When
@@ -126,9 +126,9 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param(OFFICES, OFFICE_CODE),
-              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
-              Parameter.param(SUBMISSION_PERIOD, "MAY-2025")),
+              Parameter.param(OFFICES_PARAM, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW_PARAM, LEGAL_HELP.name()),
+              Parameter.param(SUBMISSION_PERIOD_PARAM, "MAY-2025")),
           SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When
@@ -153,9 +153,9 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param(OFFICES, OFFICE_CODE),
-              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
-              Parameter.param(SUBMISSION_PERIOD, "SEP-2025")),
+              Parameter.param(OFFICES_PARAM, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW_PARAM, LEGAL_HELP.name()),
+              Parameter.param(SUBMISSION_PERIOD_PARAM, "SEP-2025")),
           SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When
@@ -183,9 +183,9 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param(OFFICES, OFFICE_CODE),
-              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
-              Parameter.param(SUBMISSION_PERIOD, APR_2025)),
+              Parameter.param(OFFICES_PARAM, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW_PARAM, LEGAL_HELP.name()),
+              Parameter.param(SUBMISSION_PERIOD_PARAM, APR_2025)),
           "data-claims/get-submission/get-submissions-by-filter.json");
 
       // When
@@ -198,7 +198,7 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
           submissionValidationContext,
           SubmissionValidationError.SUBMISSION_ALREADY_EXISTS,
           OFFICE_CODE,
-          AREA_OF_LAW,
+          LEGAL_HELP,
           APR_2025);
     }
 
@@ -214,9 +214,9 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param(OFFICES, OFFICE_CODE),
-              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
-              Parameter.param(SUBMISSION_PERIOD, APR_2025)),
+              Parameter.param(OFFICES_PARAM, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW_PARAM, LEGAL_HELP.name()),
+              Parameter.param(SUBMISSION_PERIOD_PARAM, APR_2025)),
           "data-claims/get-submission/get-submissions-by-filter-later-duplicate.json");
 
       // When
@@ -241,8 +241,8 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
       getStubForGetSubmissionByCriteria(
           List.of(
               Parameter.param("offices", OFFICE_CODE),
-              Parameter.param("area_of_law", AREA_OF_LAW.name()),
-              Parameter.param(SUBMISSION_PERIOD, "APR-2025")),
+              Parameter.param("area_of_law", LEGAL_HELP.name()),
+              Parameter.param(SUBMISSION_PERIOD_PARAM, "APR-2025")),
           SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
       stubForGetClaims(Collections.emptyList(), "data-claims/get-claims/claim-two-claims.json");
 
@@ -309,7 +309,7 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
           List.of(
               Parameter.param("offices", OFFICE_CODE),
               Parameter.param("area_of_law", AreaOfLaw.CRIME_LOWER.name()),
-              Parameter.param(SUBMISSION_PERIOD, "APR-2025")),
+              Parameter.param(SUBMISSION_PERIOD_PARAM, "APR-2025")),
           SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When

--- a/data-claims-event-service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/validator/SubmissionValidationServiceIntegrationTest.java
+++ b/data-claims-event-service/src/integrationTest/java/uk/gov/justice/laa/dstew/payments/claimsevent/validator/SubmissionValidationServiceIntegrationTest.java
@@ -45,6 +45,9 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
   private static final String OFFICE_CODE = "AQ2B3C";
   private static final AreaOfLaw AREA_OF_LAW = AreaOfLaw.LEGAL_HELP;
+  public static final String SUBMISSION_PERIOD = "submission_period";
+  public static final String SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON =
+      "data-claims/get-submission/get-submissions-by-filter_no_content.json";
 
   @Autowired protected SubmissionValidationService submissionValidationService;
 
@@ -57,6 +60,10 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
   @DisplayName("Submission period tests")
   class SubmissionPeriodTests {
 
+    public static final String OFFICES = "offices";
+    public static final String AREA_OF_LAW1 = "area_of_law";
+    public static final String APR_2025 = "APR-2025";
+
     @Test
     @DisplayName("Should have no errors with submission period in the past")
     void shouldHaveNoErrorsWithSubmissionPeriodInThePast() throws Exception {
@@ -68,10 +75,10 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param("offices", OFFICE_CODE),
-              Parameter.param("area_of_law", AREA_OF_LAW.name()),
-              Parameter.param("submission_period", "APR-2025")),
-          "data-claims/get-submission/get-submissions-by-filter_no_content.json");
+              Parameter.param(OFFICES, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
+              Parameter.param(SUBMISSION_PERIOD, APR_2025)),
+          SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When
       SubmissionValidationContext submissionValidationContext =
@@ -91,10 +98,10 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param("offices", OFFICE_CODE),
-              Parameter.param("area_of_law", AREA_OF_LAW.name()),
-              Parameter.param("submission_period", "MAR-2025")),
-          "data-claims/get-submission/get-submissions-by-filter_no_content.json");
+              Parameter.param(OFFICES, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
+              Parameter.param(SUBMISSION_PERIOD, "MAR-2025")),
+          SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When
       SubmissionValidationContext submissionValidationContext =
@@ -105,8 +112,8 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
       assertContextClaimError(
           submissionValidationContext,
           SubmissionValidationError.SUBMISSION_VALIDATION_MINIMUM_PERIOD,
-          "APR-2025",
-          "APR-2025");
+          APR_2025,
+          APR_2025);
     }
 
     @Test
@@ -119,10 +126,10 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param("offices", OFFICE_CODE),
-              Parameter.param("area_of_law", AREA_OF_LAW.name()),
-              Parameter.param("submission_period", "MAY-2025")),
-          "data-claims/get-submission/get-submissions-by-filter_no_content.json");
+              Parameter.param(OFFICES, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
+              Parameter.param(SUBMISSION_PERIOD, "MAY-2025")),
+          SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When
       SubmissionValidationContext submissionValidationContext =
@@ -146,10 +153,10 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param("offices", OFFICE_CODE),
-              Parameter.param("area_of_law", AREA_OF_LAW.name()),
-              Parameter.param("submission_period", "SEP-2025")),
-          "data-claims/get-submission/get-submissions-by-filter_no_content.json");
+              Parameter.param(OFFICES, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
+              Parameter.param(SUBMISSION_PERIOD, "SEP-2025")),
+          SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When
       SubmissionValidationContext submissionValidationContext =
@@ -176,9 +183,9 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
 
       getStubForGetSubmissionByCriteria(
           List.of(
-              Parameter.param("offices", OFFICE_CODE),
-              Parameter.param("area_of_law", AREA_OF_LAW.name()),
-              Parameter.param("submission_period", "APR-2025")),
+              Parameter.param(OFFICES, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
+              Parameter.param(SUBMISSION_PERIOD, APR_2025)),
           "data-claims/get-submission/get-submissions-by-filter.json");
 
       // When
@@ -192,7 +199,32 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
           SubmissionValidationError.SUBMISSION_ALREADY_EXISTS,
           OFFICE_CODE,
           AREA_OF_LAW,
-          "APR-2025");
+          APR_2025);
+    }
+
+    @DisplayName(
+        "Should have no error when the only matching submission was created after the one under validation")
+    @Test
+    void shouldHaveNoErrorWhenMatchingSubmissionWasCreatedLater() throws Exception {
+      // Given
+      stubForGetSubmission(SUBMISSION_ID, "data-claims/get-submission/get-submission-APR-25.json");
+      stubForUpdateSubmission(SUBMISSION_ID);
+      stubReturnNoClaims();
+      stubForUpdateBulkSubmission(BULK_SUBMISSION_ID);
+
+      getStubForGetSubmissionByCriteria(
+          List.of(
+              Parameter.param(OFFICES, OFFICE_CODE),
+              Parameter.param(AREA_OF_LAW1, AREA_OF_LAW.name()),
+              Parameter.param(SUBMISSION_PERIOD, APR_2025)),
+          "data-claims/get-submission/get-submissions-by-filter-later-duplicate.json");
+
+      // When
+      SubmissionValidationContext submissionValidationContext =
+          submissionValidationService.validateSubmission(SUBMISSION_ID);
+
+      // Then
+      assertContextHasNoErrors(submissionValidationContext);
     }
   }
 
@@ -210,8 +242,8 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
           List.of(
               Parameter.param("offices", OFFICE_CODE),
               Parameter.param("area_of_law", AREA_OF_LAW.name()),
-              Parameter.param("submission_period", "APR-2025")),
-          "data-claims/get-submission/get-submissions-by-filter_no_content.json");
+              Parameter.param(SUBMISSION_PERIOD, "APR-2025")),
+          SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
       stubForGetClaims(Collections.emptyList(), "data-claims/get-claims/claim-two-claims.json");
 
       stubForGetClaims(Collections.emptyList(), "data-claims/get-claims/no-claims.json");
@@ -277,8 +309,8 @@ public class SubmissionValidationServiceIntegrationTest extends MockServerIntegr
           List.of(
               Parameter.param("offices", OFFICE_CODE),
               Parameter.param("area_of_law", AreaOfLaw.CRIME_LOWER.name()),
-              Parameter.param("submission_period", "APR-2025")),
-          "data-claims/get-submission/get-submissions-by-filter_no_content.json");
+              Parameter.param(SUBMISSION_PERIOD, "APR-2025")),
+          SUBMISSIONS_BY_FILTER_NO_CONTENT_JSON);
 
       // When
       SubmissionValidationContext context =

--- a/data-claims-event-service/src/integrationTest/resources/responses/data-claims/get-submission/get-submissions-by-filter-later-duplicate.json
+++ b/data-claims-event-service/src/integrationTest/resources/responses/data-claims/get-submission/get-submissions-by-filter-later-duplicate.json
@@ -15,7 +15,7 @@
     "previous_submission_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "is_nil_submission": false,
     "number_of_claims": 30,
-    "submitted": "2025-05-01T12:31:00Z"
+    "submitted": "2025-05-01T12:33:00Z"
   }
   ]
 }

--- a/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/submission/SubmissionOfficeAreaOfLawAndPeriodValidator.java
+++ b/data-claims-event-service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/submission/SubmissionOfficeAreaOfLawAndPeriodValidator.java
@@ -1,7 +1,9 @@
 package uk.gov.justice.laa.dstew.payments.claimsevent.validation.submission;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -17,6 +19,16 @@ import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValida
 @Slf4j
 @RequiredArgsConstructor
 public class SubmissionOfficeAreaOfLawAndPeriodValidator implements SubmissionValidator {
+
+  /**
+   * Statuses that leave a submission "live" for duplicate-detection purposes. A submission counts
+   * as a potential duplicate unless it has reached one of these terminal states. This mirrors the
+   * partial unique index on the Data Claims API database, which enforces uniqueness of (office,
+   * area of law, submission period) across every status except these.
+   */
+  private static final Set<SubmissionStatus> NON_BLOCKING_STATUSES =
+      Set.of(SubmissionStatus.VALIDATION_FAILED, SubmissionStatus.REPLACED);
+
   private final DataClaimsRestClient dataClaimsRestClient;
 
   @Override
@@ -38,7 +50,7 @@ public class SubmissionOfficeAreaOfLawAndPeriodValidator implements SubmissionVa
 
   private Boolean isDuplicateSubmission(SubmissionResponse submission) {
 
-    final List<SubmissionBase> submissionBases =
+    final List<SubmissionBase> duplicates =
         dataClaimsRestClient
             .getSubmissions(
                 List.of(submission.getOfficeAccountNumber()),
@@ -47,13 +59,36 @@ public class SubmissionOfficeAreaOfLawAndPeriodValidator implements SubmissionVa
             .getBody()
             .getContent()
             .stream()
-            .filter(
-                submissionBase ->
-                    Objects.equals(
-                        submissionBase.getStatus(), SubmissionStatus.VALIDATION_SUCCEEDED))
+            .filter(candidate -> isDifferentSubmission(candidate, submission))
+            .filter(this::isLiveSubmission)
+            .filter(candidate -> isCreatedBefore(candidate, submission))
             .toList();
-    log.debug("Found {} duplicates for submission {}", submissionBases.size(), submission);
+    log.debug("Found {} duplicates for submission {}", duplicates.size(), submission);
 
-    return !submissionBases.isEmpty();
+    return !duplicates.isEmpty();
+  }
+
+  private boolean isDifferentSubmission(SubmissionBase candidate, SubmissionResponse submission) {
+    return !Objects.equals(candidate.getSubmissionId(), submission.getSubmissionId());
+  }
+
+  private boolean isLiveSubmission(SubmissionBase candidate) {
+    return !NON_BLOCKING_STATUSES.contains(candidate.getStatus());
+  }
+
+  /**
+   * Determines whether an existing submission was created before the one under validation.
+   *
+   * <p>The {@code submitted} timestamp is the value persisted as {@code created_on} on the
+   * submission record. Only submissions created strictly earlier are treated as duplicates, which
+   * lets the earliest of a set of concurrently submitted duplicates proceed while the later ones
+   * are rejected.
+   */
+  private boolean isCreatedBefore(SubmissionBase candidate, SubmissionResponse submission) {
+    OffsetDateTime candidateCreatedOn = candidate.getSubmitted();
+    OffsetDateTime submissionCreatedOn = submission.getSubmitted();
+    return candidateCreatedOn != null
+        && submissionCreatedOn != null
+        && candidateCreatedOn.isBefore(submissionCreatedOn);
   }
 }

--- a/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/submission/SubmissionOfficeAreaOfLawAndPeriodValidatorTest.java
+++ b/data-claims-event-service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsevent/validation/submission/SubmissionOfficeAreaOfLawAndPeriodValidatorTest.java
@@ -6,8 +6,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.laa.dstew.payments.claimsevent.ValidationServiceTestUtils.assertContextClaimError;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,10 +33,17 @@ import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValida
 import uk.gov.justice.laa.dstew.payments.claimsevent.validation.SubmissionValidationError;
 
 @ExtendWith(MockitoExtension.class)
-public class SubmissionOfficeAreaOfLawAndPeriodValidatorTest {
+@DisplayName("Submission office, area of law and period duplicate validator")
+class SubmissionOfficeAreaOfLawAndPeriodValidatorTest {
   private static final String OFFICE_CODE = "office1";
   private static final AreaOfLaw AREA_OF_LAW = AreaOfLaw.LEGAL_HELP;
   private static final String SUBMISSION_PERIOD = "2025-07";
+  private static final UUID SUBMISSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final UUID OTHER_SUBMISSION_ID =
+      UUID.fromString("00000000-0000-0000-0000-000000000002");
+  private static final OffsetDateTime CREATED_ON = OffsetDateTime.parse("2025-07-01T10:00:00Z");
+  private static final OffsetDateTime EARLIER = CREATED_ON.minusSeconds(1);
+  private static final OffsetDateTime LATER = CREATED_ON.plusSeconds(1);
 
   @Mock private DataClaimsRestClient mockDataClaimsRestClient;
 
@@ -46,9 +55,39 @@ public class SubmissionOfficeAreaOfLawAndPeriodValidatorTest {
 
   @Captor private ArgumentCaptor<String> submissionPeriodCaptor;
 
+  private static SubmissionResponse submissionUnderValidation() {
+    return SubmissionResponse.builder()
+        .submissionId(SUBMISSION_ID)
+        .officeAccountNumber(OFFICE_CODE)
+        .areaOfLaw(AREA_OF_LAW)
+        .submissionPeriod(SUBMISSION_PERIOD)
+        .submitted(CREATED_ON)
+        .build();
+  }
+
+  private static SubmissionBase existingSubmission(
+      UUID submissionId, SubmissionStatus status, OffsetDateTime createdOn) {
+    return new SubmissionBase()
+        .submissionId(submissionId)
+        .officeAccountNumber(OFFICE_CODE)
+        .areaOfLaw(AREA_OF_LAW)
+        .submissionPeriod(SUBMISSION_PERIOD)
+        .status(status)
+        .submitted(createdOn);
+  }
+
+  private void stubExistingSubmissions(SubmissionBase... submissions) {
+    var resultSet = new SubmissionsResultSet();
+    for (SubmissionBase submission : submissions) {
+      resultSet.addContentItem(submission);
+    }
+    when(mockDataClaimsRestClient.getSubmissions(any(), any(), any()))
+        .thenReturn(ResponseEntity.of(Optional.of(resultSet)));
+  }
+
   @DisplayName("Should have priority of 100")
   @Test
-  public void priority() {
+  void priority() {
     Assertions.assertEquals(100, validator.priority());
   }
 
@@ -56,7 +95,7 @@ public class SubmissionOfficeAreaOfLawAndPeriodValidatorTest {
   class Validate {
 
     @DisplayName(
-        "Should accept a submission when there is no previous submission with the same combination of Office,Area 0f law and Submission period")
+        "Should accept a submission when there is no previous submission with the same combination of Office, Area of law and Submission period")
     @Test
     void shouldAcceptSubmission() {
       when(mockDataClaimsRestClient.getSubmissions(any(), any(), any()))
@@ -64,14 +103,7 @@ public class SubmissionOfficeAreaOfLawAndPeriodValidatorTest {
 
       var submissionValidationContext = new SubmissionValidationContext();
 
-      SubmissionResponse submissionResponse =
-          SubmissionResponse.builder()
-              .officeAccountNumber(OFFICE_CODE)
-              .areaOfLaw(AREA_OF_LAW)
-              .submissionPeriod(SUBMISSION_PERIOD)
-              .build();
-
-      validator.validate(submissionResponse, submissionValidationContext);
+      validator.validate(submissionUnderValidation(), submissionValidationContext);
 
       assertThat(submissionValidationContext.hasErrors()).isFalse();
       verify(mockDataClaimsRestClient)
@@ -85,33 +117,25 @@ public class SubmissionOfficeAreaOfLawAndPeriodValidatorTest {
     }
 
     @DisplayName(
-        "Should reject a submission when there is a previous submission of status of VALIDATION_SUCCEEDED with the same combination of Office,Area 0f law and Submission period")
-    @Test
-    void shouldRejectSubmissionWhenExist() {
-      var previousExistingSubmission =
-          new SubmissionBase()
-              .officeAccountNumber(OFFICE_CODE)
-              .areaOfLaw(AREA_OF_LAW)
-              .submissionPeriod(SUBMISSION_PERIOD)
-              .status(SubmissionStatus.VALIDATION_SUCCEEDED);
-      when(mockDataClaimsRestClient.getSubmissions(any(), any(), any()))
-          .thenReturn(
-              ResponseEntity.of(
-                  Optional.of(
-                      new SubmissionsResultSet().addContentItem(previousExistingSubmission))));
+        "Should reject a submission when an earlier submission in a non-terminal status shares the same Office, Area of law and Submission period")
+    @ParameterizedTest(name = "earlier submission in status {0} is a duplicate")
+    @EnumSource(
+        value = SubmissionStatus.class,
+        names = {
+          "CREATED",
+          "READY_FOR_VALIDATION",
+          "VALIDATION_IN_PROGRESS",
+          "VALIDATION_SUCCEEDED"
+        })
+    void shouldRejectSubmissionWhenEarlierNonTerminalSubmissionExists(
+        final SubmissionStatus status) {
+      stubExistingSubmissions(existingSubmission(OTHER_SUBMISSION_ID, status, EARLIER));
 
       var submissionValidationContext = new SubmissionValidationContext();
-      SubmissionResponse submissionResponse =
-          SubmissionResponse.builder()
-              .officeAccountNumber(OFFICE_CODE)
-              .areaOfLaw(AREA_OF_LAW)
-              .submissionPeriod(SUBMISSION_PERIOD)
-              .build();
 
-      validator.validate(submissionResponse, submissionValidationContext);
+      validator.validate(submissionUnderValidation(), submissionValidationContext);
 
-      assertThat(submissionValidationContext.hasErrors()).isTrue();
-
+      assertThat(submissionValidationContext.hasErrors()).as("status %s", status).isTrue();
       assertContextClaimError(
           submissionValidationContext,
           SubmissionValidationError.SUBMISSION_ALREADY_EXISTS,
@@ -121,40 +145,45 @@ public class SubmissionOfficeAreaOfLawAndPeriodValidatorTest {
     }
 
     @DisplayName(
-        "Should accept a submission even if previous submission exist with same combination of Office, Area 0f law but status not of VALIDATION_SUCCEEDED")
-    @ParameterizedTest
+        "Should accept a submission when the only earlier submission with the same combination is in a terminal status")
+    @ParameterizedTest(name = "earlier submission in status {0} is ignored")
     @EnumSource(
         value = SubmissionStatus.class,
-        names = {
-          "CREATED",
-          "READY_FOR_VALIDATION",
-          "VALIDATION_FAILED",
-          "VALIDATION_IN_PROGRESS",
-          "REPLACED"
-        })
-    void shouldAcceptSubmissionWhenPreviousSubmissionStatusIsNotValidatedSucceeded(
-        final SubmissionStatus status) {
-      var previousExistingSubmission =
-          new SubmissionBase()
-              .officeAccountNumber(OFFICE_CODE)
-              .areaOfLaw(AREA_OF_LAW)
-              .submissionPeriod(SUBMISSION_PERIOD)
-              .status(status);
-      when(mockDataClaimsRestClient.getSubmissions(any(), any(), any()))
-          .thenReturn(
-              ResponseEntity.of(
-                  Optional.of(
-                      new SubmissionsResultSet().addContentItem(previousExistingSubmission))));
+        names = {"VALIDATION_FAILED", "REPLACED"})
+    void shouldAcceptSubmissionWhenEarlierSubmissionIsTerminal(final SubmissionStatus status) {
+      stubExistingSubmissions(existingSubmission(OTHER_SUBMISSION_ID, status, EARLIER));
 
       var submissionValidationContext = new SubmissionValidationContext();
-      SubmissionResponse submissionResponse =
-          SubmissionResponse.builder()
-              .officeAccountNumber(OFFICE_CODE)
-              .areaOfLaw(AREA_OF_LAW)
-              .submissionPeriod(SUBMISSION_PERIOD)
-              .build();
 
-      validator.validate(submissionResponse, submissionValidationContext);
+      validator.validate(submissionUnderValidation(), submissionValidationContext);
+
+      assertThat(submissionValidationContext.hasErrors()).as("status %s", status).isFalse();
+    }
+
+    @DisplayName(
+        "Should accept a submission when a non-terminal duplicate exists but was created after it, so the earliest of concurrent submissions proceeds")
+    @Test
+    void shouldAcceptSubmissionWhenDuplicateWasCreatedLater() {
+      stubExistingSubmissions(
+          existingSubmission(OTHER_SUBMISSION_ID, SubmissionStatus.READY_FOR_VALIDATION, LATER));
+
+      var submissionValidationContext = new SubmissionValidationContext();
+
+      validator.validate(submissionUnderValidation(), submissionValidationContext);
+
+      assertThat(submissionValidationContext.hasErrors()).isFalse();
+    }
+
+    @DisplayName(
+        "Should accept a submission when the only match returned is the submission under validation itself")
+    @Test
+    void shouldAcceptSubmissionWhenOnlyMatchIsItself() {
+      stubExistingSubmissions(
+          existingSubmission(SUBMISSION_ID, SubmissionStatus.READY_FOR_VALIDATION, CREATED_ON));
+
+      var submissionValidationContext = new SubmissionValidationContext();
+
+      validator.validate(submissionUnderValidation(), submissionValidationContext);
 
       assertThat(submissionValidationContext.hasErrors()).isFalse();
     }


### PR DESCRIPTION
## Summary

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1929)

**Background**
A provider submitted the same file (identical JSONB payload) twice within 10–150ms, across 6 submission periods. Each double-submit created 2 bulk_submission records and 2 PARSE_BULK_SUBMISSION messages, both of which were parsed into submissions, set to READY_FOR_VALIDATION, and validated.
The submission-level duplicate check (SubmissionOfficeAreaOfLawAndPeriodValidator) only considered existing submissions in status VALIDATION_SUCCEEDED, so a concurrent in-flight submission was invisible to the check and both were allowed through. (The claim-level duplicate check, which spans multiple statuses and would likely have caught this, is disabled for MEDIATION under BC-423.)
**Change**
The duplicate check now treats an existing submission (same Office × Area of Law × Submission Period) as a duplicate when all of the following hold:
- its status is not terminal — i.e. anything except VALIDATION_FAILED and REPLACED (mirrors the intended DB constraint);
- it was created strictly before the submission under validation (compared via submitted, the value persisted as created_on);
- it is not the submission under validation itself.
The strictly-earlier rule lets the earliest of a set of concurrently submitted duplicates proceed while rejecting the later ones.

**Scope / limitations**
- This is a mitigation, not a guarantee: if both inserts happen before either is visible to the other, both can still pass.
- The durable fix is a partial unique index in the Data Claims API DB on (office_account_number, area_of_law, submission_period) for all statuses except VALIDATION_FAILED (and possibly REPLACED). That DB change is out of scope for this PR and owned separately.

**Tests**
- Unit (SubmissionOfficeAreaOfLawAndPeriodValidatorTest): parameterised rejection for earlier submissions in CREATED, READY_FOR_VALIDATION, VALIDATION_IN_PROGRESS, VALIDATION_SUCCEEDED; acceptance for VALIDATION_FAILED/REPLACED; acceptance when the duplicate was created later; acceptance when the only match is the submission itself; acceptance when none exist.
- Integration (SubmissionValidationServiceIntegrationTest): existing duplicate test now exercises an in-flight VALIDATION_IN_PROGRESS duplicate; added a test asserting no error when the only match was created later. Test fixtures updated accordingly (distinct submission_id, earlier/later submitted timestamps).

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
